### PR TITLE
feat(v1.0.10, #64): automatically escape newline characters, fix array-like parameter serialisation.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coinbase-api",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coinbase-api",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase-api",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "Node.js SDK for Coinbase's REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/lib/BaseRestClient.ts
+++ b/src/lib/BaseRestClient.ts
@@ -177,13 +177,17 @@ export abstract class BaseRestClient {
 
     this.baseUrl = getRestBaseUrl(restClientOptions, this.getClientType());
 
+    // Newline escapes needed, if passed as env vars
     this.apiKey = this.options.apiKey;
-    this.apiSecret = this.options.apiSecret;
+    this.apiSecret = this.options.apiSecret?.replace(/\\n/g, '\n');
     this.apiPassphrase = this.options.apiPassphrase;
 
     if (restClientOptions.cdpApiKey) {
       this.apiKey = restClientOptions.cdpApiKey.name;
-      this.apiSecret = restClientOptions.cdpApiKey.privateKey;
+      this.apiSecret = restClientOptions.cdpApiKey.privateKey?.replace(
+        /\\n/g,
+        '\n',
+      );
     }
 
     // Throw if one of these values is missing, and at least one of them is set
@@ -394,6 +398,7 @@ export abstract class BaseRestClient {
 
     const strictParamValidation = this.options.strictParamValidation;
     const encodeQueryStringValues = true;
+    const explodeArrayParameters = true;
 
     const requestBody = data?.body || data;
     const requestBodyString = requestBody ? JSON.stringify(requestBody) : '';
@@ -408,8 +413,11 @@ export abstract class BaseRestClient {
               strictParamValidation,
               encodeQueryStringValues,
               '?',
+              explodeArrayParameters,
             )
           : requestBodyString;
+
+      console.log(`sign params: `, signRequestParams);
 
       // https://docs.cdp.coinbase.com/product-apis/docs/welcome
       switch (clientType) {

--- a/src/lib/BaseRestClient.ts
+++ b/src/lib/BaseRestClient.ts
@@ -417,8 +417,6 @@ export abstract class BaseRestClient {
             )
           : requestBodyString;
 
-      console.log(`sign params: `, signRequestParams);
-
       // https://docs.cdp.coinbase.com/product-apis/docs/welcome
       switch (clientType) {
         case REST_CLIENT_TYPE_ENUM.advancedTrade:

--- a/test/CBAppClient/private.test.ts
+++ b/test/CBAppClient/private.test.ts
@@ -71,7 +71,7 @@ describe('CBAppClient PRIVATE', () => {
         } catch (e: any) {
           // These are deliberately restricted API keys. If the response is a permission error, it confirms the sign + request was OK and permissions were denied.
           // console.log(`err "${expect.getState().currentTestName}"`, e?.body);
-          const responseBody = e?.body.errors[0];
+          const responseBody = e?.body?.errors[0];
 
           expect(responseBody).toMatchObject({
             id: expect.any(String),


### PR DESCRIPTION
## Summary
- Fixes frequent issue seen passing credentials via env vars, by automatically escaping new line characters
- Fixes issue serialisation seen with GET requests that allow an array of values.

<!-- Add a brief description of the pr: -->

## Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
