### PR TITLE
chore(v1.3.0): pin npm to v11 and update Node to v24.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coinbase-api",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coinbase-api",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase-api",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Node.js SDK for Coinbase's Advanced Trade, App, Exchange, International, Prime & Commerce REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Summary
- Pin npm publish workflow to npm v11 (npm v12 bug: https://github.com/npm/cli/issues/9722)
- Update `.nvmrc` to v24.18.0
- Bump package version to v1.3.0

## Test plan
- [x] npm i
- [x] npm run build
- [x] npm run lint

Made with [Cursor](https://cursor.com)