### PR TITLE
feat(v1.2.3): Advanced Trade static REST sandbox + tutorial accuracy

### DIFF
--- a/docs/COINBASE_SDK_QUICKSTART_GUIDE.md
+++ b/docs/COINBASE_SDK_QUICKSTART_GUIDE.md
@@ -538,25 +538,17 @@ function main() {
     console.error('WebSocket exception:', error);
   });
 
-  try {
-    ws.subscribe(
-      {
-        topic: 'ticker',
-        payload: {
-          product_ids: ['BTC-USD'],
-        },
+  ws.subscribe(
+    {
+      topic: 'ticker',
+      payload: {
+        product_ids: ['BTC-USD'],
       },
-      WS_KEY_MAP.advTradeMarketData,
-    );
-  } catch (error) {
-    console.error('Ticker subscription failed:', error);
-  }
+    },
+    WS_KEY_MAP.advTradeMarketData,
+  );
 
-  try {
-    ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
-  } catch (error) {
-    console.error('Heartbeat subscription failed:', error);
-  }
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
 
   process.once('SIGINT', () => {
     ws.closeAll();
@@ -626,25 +618,17 @@ function main() {
     console.error('Private WebSocket exception:', error);
   });
 
-  try {
-    ws.subscribe(
-      {
-        topic: 'user',
-        payload: {
-          product_ids: ['BTC-USD'],
-        },
+  ws.subscribe(
+    {
+      topic: 'user',
+      payload: {
+        product_ids: ['BTC-USD'],
       },
-      WS_KEY_MAP.advTradeUserData,
-    );
-  } catch (error) {
-    console.error('User subscription failed:', error);
-  }
+    },
+    WS_KEY_MAP.advTradeUserData,
+  );
 
-  try {
-    ws.subscribe('heartbeats', WS_KEY_MAP.advTradeUserData);
-  } catch (error) {
-    console.error('Heartbeat subscription failed:', error);
-  }
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeUserData);
 
   process.once('SIGINT', () => {
     ws.closeAll();
@@ -879,7 +863,7 @@ Pass `WS_KEY_MAP` values explicitly. This keeps connection routing visible and p
 
 | Channel                   | Authentication | Main use                                                   |
 | ------------------------- | -------------- | ---------------------------------------------------------- |
-| `heartbeats`              | Public         | Keep subscriptions open and detect missed heartbeat counts |
+| `heartbeats`              | Public channel | Keep subscriptions open and detect missed heartbeat counts. On `advTradeUserData`, the SDK still signs the subscription JWT |
 | `ticker`                  | Public         | Price, volume, and best bid or ask changes                 |
 | `ticker_batch`            | Public         | Batched ticker changes                                     |
 | `market_trades`           | Public         | Recent trade updates                                       |
@@ -902,6 +886,8 @@ The SDK emits:
 - `reconnected` after the replacement connection opens.
 - `close` when a connection closes.
 - `exception` for connection, parsing, signing, or subscription failures.
+
+`subscribe()` is synchronous. JWT signing and send happen asynchronously, so handle those failures on `exception` rather than wrapping `subscribe()` in `try`/`catch`.
 
 Keep each event's `wsKey`, `channel`, `sequence_num`, and event `type`. A `subscriptions` response confirms the requested channel is active. It does not replace the initial channel snapshot or later updates.
 
@@ -998,25 +984,17 @@ async function main() {
     console.error('WebSocket exception:', error);
   });
 
-  try {
-    ws.subscribe(
-      {
-        topic: 'user',
-        payload: {
-          product_ids: ['BTC-USD'],
-        },
+  ws.subscribe(
+    {
+      topic: 'user',
+      payload: {
+        product_ids: ['BTC-USD'],
       },
-      WS_KEY_MAP.advTradeUserData,
-    );
-  } catch (error) {
-    console.error('User subscription failed:', error);
-  }
+    },
+    WS_KEY_MAP.advTradeUserData,
+  );
 
-  try {
-    ws.subscribe('heartbeats', WS_KEY_MAP.advTradeUserData);
-  } catch (error) {
-    console.error('Heartbeat subscription failed:', error);
-  }
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeUserData);
 
   process.once('SIGINT', () => {
     ws.closeAll();
@@ -1062,7 +1040,7 @@ Each Coinbase client has its own default REST API host. The WebSocket client sel
 | ------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------- |
 | Advanced Trade live            | `https://api.coinbase.com`                         | `wss://advanced-trade-ws.coinbase.com` for market data                          |
 | Advanced Trade private stream  | `https://api.coinbase.com`                         | `wss://advanced-trade-ws-user.coinbase.com`                                     |
-| Advanced Trade static sandbox  | `https://api-sandbox.coinbase.com`                 | No Advanced Trade sandbox WebSocket                                             |
+| Advanced Trade static sandbox  | `https://api-sandbox.coinbase.com` via explicit `baseUrl` | No Advanced Trade sandbox WebSocket; SDK does not wire this through `useSandbox` |
 | Coinbase App live              | `https://api.coinbase.com`                         | No Coinbase App stream in this SDK                                              |
 | Coinbase Exchange live         | `https://api.exchange.coinbase.com`                | `wss://ws-feed.exchange.coinbase.com` or the authenticated direct feed          |
 | Coinbase Exchange sandbox      | `https://api-public.sandbox.exchange.coinbase.com` | `wss://ws-feed-public.sandbox.exchange.coinbase.com` or its direct sandbox feed |
@@ -1071,9 +1049,9 @@ Each Coinbase client has its own default REST API host. The WebSocket client sel
 | Coinbase Prime live            | `https://api.prime.coinbase.com`                   | `wss://ws-feed.prime.coinbase.com`                                              |
 | Legacy Commerce live           | `https://api.commerce.coinbase.com`                | No Commerce stream in this SDK                                                  |
 
-The [Advanced Trade static sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox) returns predefined mock responses for a limited set of account and order endpoints. It does not run a matching engine and is not a funded trading environment.
+The [Advanced Trade static sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox) returns predefined mock responses for a limited set of account and order endpoints. It does not run a matching engine and is not a funded trading environment. This SDK maps Advanced Trade `useSandbox: true` to an unavailable sandbox URL stub (`NoSandboxAvailable`). To call that Coinbase static sandbox host from `CBAdvancedTradeClient`, set `baseUrl: 'https://api-sandbox.coinbase.com'` explicitly.
 
-`useSandbox: true` is supported by `CBExchangeClient` and `CBInternationalClient`, and by the matching Exchange or International WebSocket connections. Sandbox credentials are separate from production credentials.
+`useSandbox: true` is supported by `CBExchangeClient` and `CBInternationalClient`, and by the matching Exchange or International WebSocket connections. On `WebsocketClient`, `useSandbox` is client-wide: it applies to every `wsKey` on that instance. Sandbox credentials are separate from production credentials.
 
 Do not set `useSandbox: true` on `CBAdvancedTradeClient` or an Advanced Trade WebSocket connection. Use public live data and `previewOrder()` for the safe Advanced Trade workflow in this tutorial.
 
@@ -1168,25 +1146,17 @@ async function main() {
     console.error('Proxied WebSocket exception:', error);
   });
 
-  try {
-    ws.subscribe(
-      {
-        topic: 'ticker',
-        payload: {
-          product_ids: ['BTC-USD'],
-        },
+  ws.subscribe(
+    {
+      topic: 'ticker',
+      payload: {
+        product_ids: ['BTC-USD'],
       },
-      WS_KEY_MAP.advTradeMarketData,
-    );
-  } catch (error) {
-    console.error('Proxied ticker subscription failed:', error);
-  }
+    },
+    WS_KEY_MAP.advTradeMarketData,
+  );
 
-  try {
-    ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
-  } catch (error) {
-    console.error('Proxied heartbeat subscription failed:', error);
-  }
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
 
   process.once('SIGINT', () => {
     ws.closeAll();
@@ -1319,25 +1289,17 @@ async function main() {
     console.error('SOCKS5 WebSocket exception:', error);
   });
 
-  try {
-    ws.subscribe(
-      {
-        topic: 'ticker',
-        payload: {
-          product_ids: ['BTC-USD'],
-        },
+  ws.subscribe(
+    {
+      topic: 'ticker',
+      payload: {
+        product_ids: ['BTC-USD'],
       },
-      WS_KEY_MAP.advTradeMarketData,
-    );
-  } catch (error) {
-    console.error('SOCKS5 ticker subscription failed:', error);
-  }
+    },
+    WS_KEY_MAP.advTradeMarketData,
+  );
 
-  try {
-    ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
-  } catch (error) {
-    console.error('SOCKS5 heartbeat subscription failed:', error);
-  }
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
 
   process.once('SIGINT', () => {
     ws.closeAll();
@@ -1439,7 +1401,7 @@ Advanced Trade is the normal Coinbase trading API for retail users. Coinbase Exc
 
 ### Does Advanced Trade have a sandbox?
 
-Coinbase provides a static Advanced Trade sandbox with predefined mock responses for selected account and order endpoints. It does not run a matching engine. `useSandbox: true` is not supported by `CBAdvancedTradeClient`.
+Coinbase provides a static Advanced Trade sandbox with predefined mock responses for selected account and order endpoints. It does not run a matching engine. `CBAdvancedTradeClient` accepts `useSandbox`, but for Advanced Trade the SDK resolves it to an unavailable sandbox URL stub. Use an explicit `baseUrl: 'https://api-sandbox.coinbase.com'` only when you intentionally need that static sandbox host.
 
 ### Does `previewOrder()` place an order?
 

--- a/docs/COINBASE_SDK_QUICKSTART_GUIDE.md
+++ b/docs/COINBASE_SDK_QUICKSTART_GUIDE.md
@@ -861,17 +861,17 @@ Pass `WS_KEY_MAP` values explicitly. This keeps connection routing visible and p
 
 ### Use the Advanced Trade channels
 
-| Channel                   | Authentication | Main use                                                   |
-| ------------------------- | -------------- | ---------------------------------------------------------- |
+| Channel                   | Authentication | Main use                                                                                                                    |
+| ------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `heartbeats`              | Public channel | Keep subscriptions open and detect missed heartbeat counts. On `advTradeUserData`, the SDK still signs the subscription JWT |
-| `ticker`                  | Public         | Price, volume, and best bid or ask changes                 |
-| `ticker_batch`            | Public         | Batched ticker changes                                     |
-| `market_trades`           | Public         | Recent trade updates                                       |
-| `level2`                  | Public         | Order-book snapshots and updates                           |
-| `candles`                 | Public         | Five-minute candle updates                                 |
-| `status`                  | Public         | Product and currency status                                |
-| `user`                    | Required       | Current open orders and later order or position changes    |
-| `futures_balance_summary` | Required       | Futures balance changes for eligible accounts              |
+| `ticker`                  | Public         | Price, volume, and best bid or ask changes                                                                                  |
+| `ticker_batch`            | Public         | Batched ticker changes                                                                                                      |
+| `market_trades`           | Public         | Recent trade updates                                                                                                        |
+| `level2`                  | Public         | Order-book snapshots and updates                                                                                            |
+| `candles`                 | Public         | Five-minute candle updates                                                                                                  |
+| `status`                  | Public         | Product and currency status                                                                                                 |
+| `user`                    | Required       | Current open orders and later order or position changes                                                                     |
+| `futures_balance_summary` | Required       | Futures balance changes for eligible accounts                                                                               |
 
 Coinbase requires one channel per Advanced Trade subscription request. Send separate `subscribe()` calls when a process needs ticker and heartbeat data.
 
@@ -1036,18 +1036,18 @@ Use Advanced Trade for a normal Coinbase retail trading account. Coinbase Exchan
 
 Each Coinbase client has its own default REST API host. The WebSocket client selects a host from the requested `wsKey`.
 
-| API or environment             | REST API host                                      | WebSocket host or guidance                                                      |
-| ------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------- |
-| Advanced Trade live            | `https://api.coinbase.com`                         | `wss://advanced-trade-ws.coinbase.com` for market data                          |
-| Advanced Trade private stream  | `https://api.coinbase.com`                         | `wss://advanced-trade-ws-user.coinbase.com`                                     |
+| API or environment             | REST API host                                             | WebSocket host or guidance                                                      |
+| ------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Advanced Trade live            | `https://api.coinbase.com`                                | `wss://advanced-trade-ws.coinbase.com` for market data                          |
+| Advanced Trade private stream  | `https://api.coinbase.com`                                | `wss://advanced-trade-ws-user.coinbase.com`                                     |
 | Advanced Trade static sandbox  | `https://api-sandbox.coinbase.com` via `useSandbox: true` | No Advanced Trade sandbox WebSocket                                             |
-| Coinbase App live              | `https://api.coinbase.com`                         | No Coinbase App stream in this SDK                                              |
-| Coinbase Exchange live         | `https://api.exchange.coinbase.com`                | `wss://ws-feed.exchange.coinbase.com` or the authenticated direct feed          |
-| Coinbase Exchange sandbox      | `https://api-public.sandbox.exchange.coinbase.com` | `wss://ws-feed-public.sandbox.exchange.coinbase.com` or its direct sandbox feed |
-| International Exchange live    | `https://api.international.coinbase.com`           | `wss://ws-md.international.coinbase.com`                                        |
-| International Exchange sandbox | `https://api-n5e1.coinbase.com`                    | `wss://ws-md.n5e2.coinbase.com`                                                 |
-| Coinbase Prime live            | `https://api.prime.coinbase.com`                   | `wss://ws-feed.prime.coinbase.com`                                              |
-| Legacy Commerce live           | `https://api.commerce.coinbase.com`                | No Commerce stream in this SDK                                                  |
+| Coinbase App live              | `https://api.coinbase.com`                                | No Coinbase App stream in this SDK                                              |
+| Coinbase Exchange live         | `https://api.exchange.coinbase.com`                       | `wss://ws-feed.exchange.coinbase.com` or the authenticated direct feed          |
+| Coinbase Exchange sandbox      | `https://api-public.sandbox.exchange.coinbase.com`        | `wss://ws-feed-public.sandbox.exchange.coinbase.com` or its direct sandbox feed |
+| International Exchange live    | `https://api.international.coinbase.com`                  | `wss://ws-md.international.coinbase.com`                                        |
+| International Exchange sandbox | `https://api-n5e1.coinbase.com`                           | `wss://ws-md.n5e2.coinbase.com`                                                 |
+| Coinbase Prime live            | `https://api.prime.coinbase.com`                          | `wss://ws-feed.prime.coinbase.com`                                              |
+| Legacy Commerce live           | `https://api.commerce.coinbase.com`                       | No Commerce stream in this SDK                                                  |
 
 The [Advanced Trade static sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox) returns predefined mock responses for a limited set of account and order endpoints. It does not run a matching engine and is not a funded trading environment. Enable it on `CBAdvancedTradeClient` with `useSandbox: true` (REST only). There is no Advanced Trade WebSocket sandbox.
 

--- a/docs/COINBASE_SDK_QUICKSTART_GUIDE.md
+++ b/docs/COINBASE_SDK_QUICKSTART_GUIDE.md
@@ -1040,7 +1040,7 @@ Each Coinbase client has its own default REST API host. The WebSocket client sel
 | ------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------- |
 | Advanced Trade live            | `https://api.coinbase.com`                         | `wss://advanced-trade-ws.coinbase.com` for market data                          |
 | Advanced Trade private stream  | `https://api.coinbase.com`                         | `wss://advanced-trade-ws-user.coinbase.com`                                     |
-| Advanced Trade static sandbox  | `https://api-sandbox.coinbase.com` via explicit `baseUrl` | No Advanced Trade sandbox WebSocket; SDK does not wire this through `useSandbox` |
+| Advanced Trade static sandbox  | `https://api-sandbox.coinbase.com` via `useSandbox: true` | No Advanced Trade sandbox WebSocket                                             |
 | Coinbase App live              | `https://api.coinbase.com`                         | No Coinbase App stream in this SDK                                              |
 | Coinbase Exchange live         | `https://api.exchange.coinbase.com`                | `wss://ws-feed.exchange.coinbase.com` or the authenticated direct feed          |
 | Coinbase Exchange sandbox      | `https://api-public.sandbox.exchange.coinbase.com` | `wss://ws-feed-public.sandbox.exchange.coinbase.com` or its direct sandbox feed |
@@ -1049,11 +1049,19 @@ Each Coinbase client has its own default REST API host. The WebSocket client sel
 | Coinbase Prime live            | `https://api.prime.coinbase.com`                   | `wss://ws-feed.prime.coinbase.com`                                              |
 | Legacy Commerce live           | `https://api.commerce.coinbase.com`                | No Commerce stream in this SDK                                                  |
 
-The [Advanced Trade static sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox) returns predefined mock responses for a limited set of account and order endpoints. It does not run a matching engine and is not a funded trading environment. This SDK maps Advanced Trade `useSandbox: true` to an unavailable sandbox URL stub (`NoSandboxAvailable`). To call that Coinbase static sandbox host from `CBAdvancedTradeClient`, set `baseUrl: 'https://api-sandbox.coinbase.com'` explicitly.
+The [Advanced Trade static sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox) returns predefined mock responses for a limited set of account and order endpoints. It does not run a matching engine and is not a funded trading environment. Enable it on `CBAdvancedTradeClient` with `useSandbox: true` (REST only). There is no Advanced Trade WebSocket sandbox.
 
-`useSandbox: true` is supported by `CBExchangeClient` and `CBInternationalClient`, and by the matching Exchange or International WebSocket connections. On `WebsocketClient`, `useSandbox` is client-wide: it applies to every `wsKey` on that instance. Sandbox credentials are separate from production credentials.
+`useSandbox: true` is also supported by `CBExchangeClient` and `CBInternationalClient`, and by the matching Exchange or International WebSocket connections. On `WebsocketClient`, `useSandbox` is client-wide: it applies to every `wsKey` on that instance. Do not set `useSandbox: true` on an Advanced Trade WebSocket connection. Sandbox credentials are separate from production credentials where the product requires them. Advanced Trade's static sandbox also accepts unauthenticated requests for its mocked endpoints.
 
-Do not set `useSandbox: true` on `CBAdvancedTradeClient` or an Advanced Trade WebSocket connection. Use public live data and `previewOrder()` for the safe Advanced Trade workflow in this tutorial.
+```javascript
+import { CBAdvancedTradeClient } from 'coinbase-api';
+
+const sandboxRest = new CBAdvancedTradeClient({
+  useSandbox: true,
+});
+```
+
+This tutorial's order examples still use live public market data plus `previewOrder()` for the safe Advanced Trade workflow.
 
 Official environment references:
 
@@ -1401,7 +1409,7 @@ Advanced Trade is the normal Coinbase trading API for retail users. Coinbase Exc
 
 ### Does Advanced Trade have a sandbox?
 
-Coinbase provides a static Advanced Trade sandbox with predefined mock responses for selected account and order endpoints. It does not run a matching engine. `CBAdvancedTradeClient` accepts `useSandbox`, but for Advanced Trade the SDK resolves it to an unavailable sandbox URL stub. Use an explicit `baseUrl: 'https://api-sandbox.coinbase.com'` only when you intentionally need that static sandbox host.
+Yes, a static REST sandbox. `useSandbox: true` on `CBAdvancedTradeClient` routes to `https://api-sandbox.coinbase.com`. Responses are predefined mocks for selected account and order endpoints. It does not run a matching engine, and there is no Advanced Trade WebSocket sandbox.
 
 ### Does `previewOrder()` place an order?
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coinbase-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coinbase-api",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase-api",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Node.js SDK for Coinbase's Advanced Trade, App, Exchange, International, Prime & Commerce REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/lib/requestUtils.ts
+++ b/src/lib/requestUtils.ts
@@ -35,7 +35,9 @@ const exchangeSandboxURLMap = {
   [REST_CLIENT_TYPE_ENUM.exchange]:
     'https://api-public.sandbox.exchange.coinbase.com',
   [REST_CLIENT_TYPE_ENUM.international]: 'https://api-n5e1.coinbase.com',
-  [REST_CLIENT_TYPE_ENUM.advancedTrade]: 'NoSandboxAvailable',
+  // Static Advanced Trade sandbox (mocked accounts/orders). No matching engine / WebSocket sandbox.
+  // https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox
+  [REST_CLIENT_TYPE_ENUM.advancedTrade]: 'https://api-sandbox.coinbase.com',
   [REST_CLIENT_TYPE_ENUM.coinbaseApp]: 'NoSandboxAvailable',
   [REST_CLIENT_TYPE_ENUM.prime]: 'NoSandboxAvailable',
   [REST_CLIENT_TYPE_ENUM.commerce]: 'NoSandboxAvailable',
@@ -98,12 +100,14 @@ export interface RestClientOptions {
   /**
    * Connect to the sandbox for supported products
    *
+   * - Coinbase Advanced Trade: static REST sandbox (mocked accounts/orders, no matching engine):
+   *   https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox
    * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
    * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
    *
    * - Coinbase App: No sandbox available.
-   * - Coinbase Advanced Trade: No sandbox available.
    * - Coinbase Prime: No sandbox available.
+   * - Coinbase Commerce: No sandbox available.
    */
   useSandbox?: boolean;
 

--- a/src/types/websockets/client.ts
+++ b/src/types/websockets/client.ts
@@ -55,8 +55,8 @@ export interface WSClientConfigurableOptions {
    * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
    * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
    *
+   * - Coinbase Advanced Trade: No WebSocket sandbox (REST static sandbox only via RestClientOptions.useSandbox).
    * - Coinbase App: No sandbox available.
-   * - Coinbase Advanced Trade: No sandbox available.
    * - Coinbase Prime: No sandbox available.
    */
   useSandbox?: boolean;


### PR DESCRIPTION
## Summary
- Wire Advanced Trade static REST sandbox: `useSandbox: true` on `CBAdvancedTradeClient` now routes to `https://api-sandbox.coinbase.com` (was `NoSandboxAvailable`).
- Bump version to **1.2.3**.
- Update tutorial: sandbox hosts, FAQ, and `useSandbox` example. Keep no Advanced Trade WebSocket sandbox.
- Keep prior tutorial accuracy fixes (sync `subscribe()` / `exception` handling, heartbeats signing note).
- No `X-Sandbox` variance-header helper in this PR.

## Test plan
- [ ] `new CBAdvancedTradeClient({ useSandbox: true })` hits `https://api-sandbox.coinbase.com`
- [ ] Live AT still defaults to `https://api.coinbase.com`
- [ ] Exchange / INTX sandbox hosts unchanged
- [ ] Advanced Trade WS `useSandbox` still resolves to unavailable
- [ ] Tutorial sandbox section matches SDK behavior

