### PR TITLE
feat(v1.2.4): add Coinbase One subscription and travel rule data endpoints

### DIFF
--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -4,8 +4,8 @@
 <p align="center">
   <a href="https://www.npmjs.com/package/coinbase-api">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/coinbase-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/coinbase-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/sieblyio/coinbase-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/sieblyio/coinbase-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
     </picture>
   </a>
 </p>
@@ -14,7 +14,7 @@ Each REST client is a JavaScript class, which provides functions individually ma
 
 The following table shows all methods available in each REST client, whether the method requires authentication (automatically handled if API keys are provided), as well as the exact endpoint each method is connected to.
 
-This can be used to easily find which method to call, once you have [found which endpoint you're looking to use](https://github.com/tiagosiebler/awesome-crypto-examples/wiki/How-to-find-SDK-functions-that-match-API-docs-endpoint).
+This can be used to easily find which method to call, once you have [found which endpoint you're looking to use](https://github.com/sieblyio/awesome-crypto-examples/wiki/How-to-find-SDK-functions-that-match-API-docs-endpoint).
 
 All REST clients are in the [src](/src) folder. For usage examples, make sure to check the [examples](/examples) folder.
 
@@ -53,56 +53,56 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAccounts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L149) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/accounts` |
-| [getAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L163) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/accounts/{account_id}` |
-| [getBestBidAsk()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L180) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/best_bid_ask` |
-| [getProductBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L191) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/product_book` |
-| [getProducts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L205) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products` |
-| [getProduct()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L217) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products/{product_id}` |
-| [getProductCandles()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L233) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products/{product_id}/candles` |
-| [getMarketTrades()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L248) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products/{product_id}/ticker` |
-| [submitOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L270) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders` |
-| [cancelOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L287) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/batch_cancel` |
-| [updateOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L304) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/edit` |
-| [updateOrderPreview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L318) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/edit_preview` |
-| [getOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L336) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/orders/historical/batch` |
-| [getFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L351) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/orders/historical/fills` |
-| [getOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L363) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/orders/historical/{order_id}` |
-| [previewOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L381) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/preview` |
-| [closePosition()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L395) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/close_position` |
-| [getPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L415) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/portfolios` |
-| [createPortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L428) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/portfolios` |
-| [movePortfolioFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L441) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/portfolios/move_funds` |
-| [getPortfolioBreakdown()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L455) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/portfolios/{portfolio_uuid}` |
-| [deletePortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L471) | :closed_lock_with_key:  | DELETE | `/api/v3/brokerage/portfolios/{portfolio_uuid}` |
-| [updatePortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L482) | :closed_lock_with_key:  | PUT | `/api/v3/brokerage/portfolios/{portfolio_uuid}` |
-| [getFuturesBalanceSummary()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L513) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/balance_summary` |
-| [getIntradayMarginSetting()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L524) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/intraday/margin_setting` |
-| [setIntradayMarginSetting()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L538) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/cfm/intraday/margin_setting` |
-| [getCurrentMarginWindow()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L554) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/intraday/current_margin_window` |
-| [getFuturesPositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L571) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/positions` |
-| [getFuturesPosition()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L580) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/positions/{product_id}` |
-| [scheduleFuturesSweep()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L600) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/cfm/sweeps/schedule` |
-| [getFuturesSweeps()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L618) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/sweeps` |
-| [cancelPendingFuturesSweep()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L627) | :closed_lock_with_key:  | DELETE | `/api/v3/brokerage/cfm/sweeps` |
-| [allocatePortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L643) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/intx/allocate` |
-| [getPerpetualsPortfolioSummary()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L654) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/portfolio/{portfolio_uuid}` |
-| [getPerpetualsPositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L668) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/positions/{portfolio_uuid}` |
-| [getPerpetualsPosition()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L683) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/positions/{portfolio_uuid}/{symbol}` |
-| [getPortfoliosBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L698) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/balances/{portfolio_uuid}` |
-| [updateMultiAssetCollateral()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L710) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/intx/multi_asset_collateral` |
-| [getTransactionSummary()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L730) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/transaction_summary` |
-| [submitConvertQuote()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L748) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/convert/quote` |
-| [getConvertTrade()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L759) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/convert/trade/{trade_id}` |
-| [commitConvertTrade()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L776) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/convert/trade/{trade_id}` |
-| [getPublicProductBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L806) |  | GET | `/api/v3/brokerage/market/product_book` |
-| [getPublicProducts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L819) |  | GET | `/api/v3/brokerage/market/products` |
-| [getPublicProduct()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L831) |  | GET | `/api/v3/brokerage/market/products/{product_id}` |
-| [getPublicProductCandles()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L843) |  | GET | `/api/v3/brokerage/market/products/{product_id}/candles` |
-| [getPublicMarketTrades()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L858) |  | GET | `/api/v3/brokerage/market/products/{product_id}/ticker` |
-| [getPaymentMethods()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L879) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/payment_methods` |
-| [getPaymentMethod()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L890) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/payment_methods/{payment_method_id}` |
-| [getApiKeyPermissions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L910) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/key_permissions` |
+| [getAccounts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L149) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/accounts` |
+| [getAccount()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L163) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/accounts/{account_id}` |
+| [getBestBidAsk()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L180) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/best_bid_ask` |
+| [getProductBook()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L191) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/product_book` |
+| [getProducts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L205) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products` |
+| [getProduct()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L217) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products/{product_id}` |
+| [getProductCandles()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L233) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products/{product_id}/candles` |
+| [getMarketTrades()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L248) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/products/{product_id}/ticker` |
+| [submitOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L270) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders` |
+| [cancelOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L287) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/batch_cancel` |
+| [updateOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L304) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/edit` |
+| [updateOrderPreview()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L318) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/edit_preview` |
+| [getOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L336) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/orders/historical/batch` |
+| [getFills()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L351) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/orders/historical/fills` |
+| [getOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L363) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/orders/historical/{order_id}` |
+| [previewOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L381) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/preview` |
+| [closePosition()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L395) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/orders/close_position` |
+| [getPortfolios()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L415) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/portfolios` |
+| [createPortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L428) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/portfolios` |
+| [movePortfolioFunds()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L441) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/portfolios/move_funds` |
+| [getPortfolioBreakdown()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L455) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/portfolios/{portfolio_uuid}` |
+| [deletePortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L471) | :closed_lock_with_key:  | DELETE | `/api/v3/brokerage/portfolios/{portfolio_uuid}` |
+| [updatePortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L482) | :closed_lock_with_key:  | PUT | `/api/v3/brokerage/portfolios/{portfolio_uuid}` |
+| [getFuturesBalanceSummary()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L513) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/balance_summary` |
+| [getIntradayMarginSetting()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L524) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/intraday/margin_setting` |
+| [setIntradayMarginSetting()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L538) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/cfm/intraday/margin_setting` |
+| [getCurrentMarginWindow()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L554) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/intraday/current_margin_window` |
+| [getFuturesPositions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L571) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/positions` |
+| [getFuturesPosition()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L580) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/positions/{product_id}` |
+| [scheduleFuturesSweep()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L600) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/cfm/sweeps/schedule` |
+| [getFuturesSweeps()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L618) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/cfm/sweeps` |
+| [cancelPendingFuturesSweep()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L627) | :closed_lock_with_key:  | DELETE | `/api/v3/brokerage/cfm/sweeps` |
+| [allocatePortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L643) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/intx/allocate` |
+| [getPerpetualsPortfolioSummary()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L654) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/portfolio/{portfolio_uuid}` |
+| [getPerpetualsPositions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L668) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/positions/{portfolio_uuid}` |
+| [getPerpetualsPosition()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L683) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/positions/{portfolio_uuid}/{symbol}` |
+| [getPortfoliosBalances()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L698) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/intx/balances/{portfolio_uuid}` |
+| [updateMultiAssetCollateral()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L710) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/intx/multi_asset_collateral` |
+| [getTransactionSummary()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L730) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/transaction_summary` |
+| [submitConvertQuote()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L748) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/convert/quote` |
+| [getConvertTrade()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L759) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/convert/trade/{trade_id}` |
+| [commitConvertTrade()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L776) | :closed_lock_with_key:  | POST | `/api/v3/brokerage/convert/trade/{trade_id}` |
+| [getPublicProductBook()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L806) |  | GET | `/api/v3/brokerage/market/product_book` |
+| [getPublicProducts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L819) |  | GET | `/api/v3/brokerage/market/products` |
+| [getPublicProduct()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L831) |  | GET | `/api/v3/brokerage/market/products/{product_id}` |
+| [getPublicProductCandles()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L843) |  | GET | `/api/v3/brokerage/market/products/{product_id}/candles` |
+| [getPublicMarketTrades()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L858) |  | GET | `/api/v3/brokerage/market/products/{product_id}/ticker` |
+| [getPaymentMethods()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L879) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/payment_methods` |
+| [getPaymentMethod()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L890) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/payment_methods/{payment_method_id}` |
+| [getApiKeyPermissions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAdvancedTradeClient.ts#L910) | :closed_lock_with_key:  | GET | `/api/v3/brokerage/key_permissions` |
 
 # CBAppClient.ts
 
@@ -110,32 +110,32 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAccounts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L67) | :closed_lock_with_key:  | GET | `/v2/accounts` |
-| [getAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L86) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}` |
-| [createAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L103) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/addresses` |
-| [getAddresses()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L119) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses` |
-| [getAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L145) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}` |
-| [getAddressTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L162) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}/transactions` |
-| [sendMoney()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L198) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
-| [transferMoney()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L213) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
-| [getTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L230) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions` |
-| [getTransaction()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L256) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions/{transactionId}` |
-| [depositFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L278) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits` |
-| [commitDeposit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L290) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits/{deposit_id}/commit` |
-| [getDeposits()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L307) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits` |
-| [getDeposit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L327) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits/{deposit_id}` |
-| [withdrawFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L346) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals` |
-| [commitWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L358) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}/commit` |
-| [getWithdrawals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L375) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals` |
-| [getWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L401) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}` |
-| [getCoinbaseOneSubscription()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L424) | :closed_lock_with_key:  | GET | `/v2/subscriptions/coinbase-one` |
-| [getFiatCurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L442) |  | GET | `/v2/currencies` |
-| [getCryptocurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L453) |  | GET | `/v2/currencies/crypto` |
-| [getExchangeRates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L469) |  | GET | `/v2/exchange-rates` |
-| [getBuyPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L490) |  | GET | `/v2/prices/{currencyPair}/buy` |
-| [getSellPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L505) |  | GET | `/v2/prices/{currencyPair}/sell` |
-| [getSpotPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L520) |  | GET | `/v2/prices/{currencyPair}/spot` |
-| [getCurrentTime()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L542) |  | GET | `/v2/time` |
+| [getAccounts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L67) | :closed_lock_with_key:  | GET | `/v2/accounts` |
+| [getAccount()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L86) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}` |
+| [createAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L103) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/addresses` |
+| [getAddresses()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L119) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses` |
+| [getAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L145) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}` |
+| [getAddressTransactions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L162) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}/transactions` |
+| [sendMoney()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L198) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
+| [transferMoney()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L213) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
+| [getTransactions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L230) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions` |
+| [getTransaction()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L256) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions/{transactionId}` |
+| [depositFunds()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L278) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits` |
+| [commitDeposit()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L290) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits/{deposit_id}/commit` |
+| [getDeposits()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L307) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits` |
+| [getDeposit()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L327) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits/{deposit_id}` |
+| [withdrawFunds()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L346) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals` |
+| [commitWithdrawal()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L358) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}/commit` |
+| [getWithdrawals()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L375) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals` |
+| [getWithdrawal()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L401) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}` |
+| [getCoinbaseOneSubscription()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L424) | :closed_lock_with_key:  | GET | `/v2/subscriptions/coinbase-one` |
+| [getFiatCurrencies()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L442) |  | GET | `/v2/currencies` |
+| [getCryptocurrencies()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L453) |  | GET | `/v2/currencies/crypto` |
+| [getExchangeRates()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L469) |  | GET | `/v2/exchange-rates` |
+| [getBuyPrice()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L490) |  | GET | `/v2/prices/{currencyPair}/buy` |
+| [getSellPrice()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L505) |  | GET | `/v2/prices/{currencyPair}/sell` |
+| [getSpotPrice()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L520) |  | GET | `/v2/prices/{currencyPair}/spot` |
+| [getCurrentTime()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBAppClient.ts#L542) |  | GET | `/v2/time` |
 
 # CBExchangeClient.ts
 
@@ -143,83 +143,83 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAccounts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L72) | :closed_lock_with_key:  | GET | `/accounts` |
-| [getAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L81) | :closed_lock_with_key:  | GET | `/accounts/{account_id}` |
-| [getAccountHolds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L92) | :closed_lock_with_key:  | GET | `/accounts/{account_id}/holds` |
-| [getAccountLedger()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L111) | :closed_lock_with_key:  | GET | `/accounts/{account_id}/ledger` |
-| [getAccountTransfers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L121) | :closed_lock_with_key:  | GET | `/accounts/{account_id}/transfers` |
-| [getAddressBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L137) | :closed_lock_with_key:  | GET | `/address-book` |
-| [addAddresses()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L146) | :closed_lock_with_key:  | POST | `/address-book` |
-| [deleteAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L155) | :closed_lock_with_key:  | DELETE | `/address-book/{id}` |
-| [getCounterpartyAddressBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L164) | :closed_lock_with_key:  | GET | `/address-book/counterparty` |
-| [updateAddressBookEntry()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L173) | :closed_lock_with_key:  | PUT | `/address-book/{id}` |
-| [getCoinbaseWallets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L191) | :closed_lock_with_key:  | GET | `/coinbase-accounts` |
-| [createNewCryptoAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L200) | :closed_lock_with_key:  | POST | `/coinbase-accounts/{account_id}/addresses` |
-| [convertCurrency()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L218) | :closed_lock_with_key:  | POST | `/conversions` |
-| [getConversionFeeRates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L227) | :closed_lock_with_key:  | GET | `/conversions/fees` |
-| [getConversion()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L236) | :closed_lock_with_key:  | GET | `/conversions/{conversion_id}` |
-| [getAllConversions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L249) | :closed_lock_with_key:  | GET | `/conversions` |
-| [getCurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L269) |  | GET | `/currencies` |
-| [getCurrency()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L278) |  | GET | `/currencies/{currency_id}` |
-| [depositFromCoinbaseAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L293) | :closed_lock_with_key:  | POST | `/deposits/coinbase-account` |
-| [depositFromPaymentMethod()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L307) | :closed_lock_with_key:  | POST | `/deposits/payment-method` |
-| [getPaymentMethods()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L318) | :closed_lock_with_key:  | GET | `/payment-methods` |
-| [getTransfers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L327) | :closed_lock_with_key:  | GET | `/transfers` |
-| [getTransfer()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L336) | :closed_lock_with_key:  | GET | `/transfers/{transfer_id}` |
-| [submitTravelInformation()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L345) | :closed_lock_with_key:  | POST | `/transfers/{transfer_id}/travel-rules` |
-| [withdrawToCoinbaseAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L359) | :closed_lock_with_key:  | POST | `/withdrawals/coinbase-account` |
-| [withdrawToCryptoAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L368) | :closed_lock_with_key:  | POST | `/withdrawals/crypto` |
-| [getCryptoWithdrawalFeeEstimate()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L377) | :closed_lock_with_key:  | GET | `/withdrawals/fee-estimate` |
-| [withdrawToPaymentMethod()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L389) | :closed_lock_with_key:  | POST | `/withdrawals/payment-method` |
-| [getFees()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L405) | :closed_lock_with_key:  | GET | `/fees` |
-| [getFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L420) | :closed_lock_with_key:  | GET | `/fills` |
-| [getOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L430) | :closed_lock_with_key:  | GET | `/orders` |
-| [cancelAllOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L439) | :closed_lock_with_key:  | DELETE | `/orders` |
-| [submitOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L452) | :closed_lock_with_key:  | POST | `/orders` |
-| [getOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L462) | :closed_lock_with_key:  | GET | `/orders/{order_id}` |
-| [cancelOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L472) | :closed_lock_with_key:  | DELETE | `/orders/{order_id}` |
-| [getLoans()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L490) | :closed_lock_with_key:  | GET | `/loans` |
-| [getLoanAssets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L499) | :closed_lock_with_key:  | GET | `/loans/assets` |
-| [getInterestSummaries()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L508) | :closed_lock_with_key:  | GET | `/loans/interest` |
-| [getInterestRateHistory()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L517) | :closed_lock_with_key:  | GET | `/loans/interest/history/{loan_id}` |
-| [getInterestCharges()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L526) | :closed_lock_with_key:  | GET | `/loans/interest/{loan_id}` |
-| [getLendingOverview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L538) | :closed_lock_with_key:  | GET | `/loans/lending-overview` |
-| [getNewLoanPreview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L549) | :closed_lock_with_key:  | GET | `/loans/loan-preview` |
-| [submitNewLoan()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L562) | :closed_lock_with_key:  | POST | `/loans/open` |
-| [getNewLoanOptions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L571) | :closed_lock_with_key:  | GET | `/loans/options` |
-| [repayLoanInterest()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L580) | :closed_lock_with_key:  | POST | `/loans/repay-interest` |
-| [repayLoanPrincipal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L589) | :closed_lock_with_key:  | POST | `/loans/repay-principal` |
-| [getPrincipalRepaymentPreview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L599) | :closed_lock_with_key:  | GET | `/loans/repayment-preview` |
-| [getSignedPrices()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L616) | :closed_lock_with_key:  | GET | `/oracle` |
-| [getAllTradingPairs()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L631) |  | GET | `/products` |
-| [getAllProductVolume()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L640) |  | GET | `/products/volume-summary` |
-| [getProduct()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L649) |  | GET | `/products/{product_id}` |
-| [getProductBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L660) |  | GET | `/products/{product_id}/book` |
-| [getProductCandles()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L671) |  | GET | `/products/{product_id}/candles` |
-| [getProductStats()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L681) |  | GET | `/products/{product_id}/stats` |
-| [getProductTicker()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L690) |  | GET | `/products/{product_id}/ticker` |
-| [getProductTrades()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L699) |  | GET | `/products/{product_id}/trades` |
-| [getProfiles()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L715) | :closed_lock_with_key:  | GET | `/profiles` |
-| [createProfile()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L724) | :closed_lock_with_key:  | POST | `/profiles` |
-| [transferFundsBetweenProfiles()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L733) | :closed_lock_with_key:  | POST | `/profiles/transfer` |
-| [getProfileById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L744) | :closed_lock_with_key:  | GET | `/profiles/{profile_id}` |
-| [renameProfile()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L757) | :closed_lock_with_key:  | PUT | `/profiles/{profile_id}` |
-| [deleteProfile()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L768) | :closed_lock_with_key:  | PUT | `/profiles/{profile_id}/deactivate` |
-| [getAllReports()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L786) | :closed_lock_with_key:  | GET | `/reports` |
-| [createReport()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L796) | :closed_lock_with_key:  | POST | `/reports` |
-| [getReport()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L805) | :closed_lock_with_key:  | GET | `/reports/{report_id}` |
-| [getTravelRuleInformation()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L820) | :closed_lock_with_key:  | GET | `/travel-rules` |
-| [createTravelRuleEntry()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L831) | :closed_lock_with_key:  | POST | `/travel-rules` |
-| [deleteTravelRuleEntry()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L844) | :closed_lock_with_key:  | DELETE | `/travel-rules/{id}` |
-| [getUserExchangeLimits()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L859) | :closed_lock_with_key:  | GET | `/users/{user_id}/exchange-limits` |
-| [updateSettlementPreference()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L868) | :closed_lock_with_key:  | POST | `/users/{user_id}/settlement-preferences` |
-| [getUserTradingVolume()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L883) | :closed_lock_with_key:  | GET | `/users/{user_id}/trading-volumes` |
-| [getAllWrappedAssets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L898) |  | GET | `/wrapped-assets` |
-| [getAllStakeWraps()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L907) | :closed_lock_with_key:  | GET | `/wrapped-assets/stake-wrap` |
-| [createStakeWrap()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L916) | :closed_lock_with_key:  | POST | `/wrapped-assets/stake-wrap` |
-| [getStakeWrap()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L929) | :closed_lock_with_key:  | GET | `/wrapped-assets/stake-wrap/{stake_wrap_id}` |
-| [getWrappedAssetDetails()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L940) | :closed_lock_with_key:  | GET | `/wrapped-assets/{wrapped_asset_id}` |
-| [getWrappedAssetConversionRate()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBExchangeClient.ts#L949) | :closed_lock_with_key:  | GET | `/wrapped-assets/{wrapped_asset_id}/conversion-rate` |
+| [getAccounts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L72) | :closed_lock_with_key:  | GET | `/accounts` |
+| [getAccount()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L81) | :closed_lock_with_key:  | GET | `/accounts/{account_id}` |
+| [getAccountHolds()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L92) | :closed_lock_with_key:  | GET | `/accounts/{account_id}/holds` |
+| [getAccountLedger()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L111) | :closed_lock_with_key:  | GET | `/accounts/{account_id}/ledger` |
+| [getAccountTransfers()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L121) | :closed_lock_with_key:  | GET | `/accounts/{account_id}/transfers` |
+| [getAddressBook()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L137) | :closed_lock_with_key:  | GET | `/address-book` |
+| [addAddresses()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L146) | :closed_lock_with_key:  | POST | `/address-book` |
+| [deleteAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L155) | :closed_lock_with_key:  | DELETE | `/address-book/{id}` |
+| [getCounterpartyAddressBook()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L164) | :closed_lock_with_key:  | GET | `/address-book/counterparty` |
+| [updateAddressBookEntry()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L173) | :closed_lock_with_key:  | PUT | `/address-book/{id}` |
+| [getCoinbaseWallets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L191) | :closed_lock_with_key:  | GET | `/coinbase-accounts` |
+| [createNewCryptoAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L200) | :closed_lock_with_key:  | POST | `/coinbase-accounts/{account_id}/addresses` |
+| [convertCurrency()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L218) | :closed_lock_with_key:  | POST | `/conversions` |
+| [getConversionFeeRates()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L227) | :closed_lock_with_key:  | GET | `/conversions/fees` |
+| [getConversion()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L236) | :closed_lock_with_key:  | GET | `/conversions/{conversion_id}` |
+| [getAllConversions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L249) | :closed_lock_with_key:  | GET | `/conversions` |
+| [getCurrencies()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L269) |  | GET | `/currencies` |
+| [getCurrency()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L278) |  | GET | `/currencies/{currency_id}` |
+| [depositFromCoinbaseAccount()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L293) | :closed_lock_with_key:  | POST | `/deposits/coinbase-account` |
+| [depositFromPaymentMethod()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L307) | :closed_lock_with_key:  | POST | `/deposits/payment-method` |
+| [getPaymentMethods()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L318) | :closed_lock_with_key:  | GET | `/payment-methods` |
+| [getTransfers()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L327) | :closed_lock_with_key:  | GET | `/transfers` |
+| [getTransfer()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L336) | :closed_lock_with_key:  | GET | `/transfers/{transfer_id}` |
+| [submitTravelInformation()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L345) | :closed_lock_with_key:  | POST | `/transfers/{transfer_id}/travel-rules` |
+| [withdrawToCoinbaseAccount()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L359) | :closed_lock_with_key:  | POST | `/withdrawals/coinbase-account` |
+| [withdrawToCryptoAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L368) | :closed_lock_with_key:  | POST | `/withdrawals/crypto` |
+| [getCryptoWithdrawalFeeEstimate()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L377) | :closed_lock_with_key:  | GET | `/withdrawals/fee-estimate` |
+| [withdrawToPaymentMethod()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L389) | :closed_lock_with_key:  | POST | `/withdrawals/payment-method` |
+| [getFees()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L405) | :closed_lock_with_key:  | GET | `/fees` |
+| [getFills()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L420) | :closed_lock_with_key:  | GET | `/fills` |
+| [getOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L430) | :closed_lock_with_key:  | GET | `/orders` |
+| [cancelAllOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L439) | :closed_lock_with_key:  | DELETE | `/orders` |
+| [submitOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L452) | :closed_lock_with_key:  | POST | `/orders` |
+| [getOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L462) | :closed_lock_with_key:  | GET | `/orders/{order_id}` |
+| [cancelOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L472) | :closed_lock_with_key:  | DELETE | `/orders/{order_id}` |
+| [getLoans()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L490) | :closed_lock_with_key:  | GET | `/loans` |
+| [getLoanAssets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L499) | :closed_lock_with_key:  | GET | `/loans/assets` |
+| [getInterestSummaries()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L508) | :closed_lock_with_key:  | GET | `/loans/interest` |
+| [getInterestRateHistory()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L517) | :closed_lock_with_key:  | GET | `/loans/interest/history/{loan_id}` |
+| [getInterestCharges()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L526) | :closed_lock_with_key:  | GET | `/loans/interest/{loan_id}` |
+| [getLendingOverview()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L538) | :closed_lock_with_key:  | GET | `/loans/lending-overview` |
+| [getNewLoanPreview()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L549) | :closed_lock_with_key:  | GET | `/loans/loan-preview` |
+| [submitNewLoan()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L562) | :closed_lock_with_key:  | POST | `/loans/open` |
+| [getNewLoanOptions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L571) | :closed_lock_with_key:  | GET | `/loans/options` |
+| [repayLoanInterest()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L580) | :closed_lock_with_key:  | POST | `/loans/repay-interest` |
+| [repayLoanPrincipal()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L589) | :closed_lock_with_key:  | POST | `/loans/repay-principal` |
+| [getPrincipalRepaymentPreview()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L599) | :closed_lock_with_key:  | GET | `/loans/repayment-preview` |
+| [getSignedPrices()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L616) | :closed_lock_with_key:  | GET | `/oracle` |
+| [getAllTradingPairs()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L631) |  | GET | `/products` |
+| [getAllProductVolume()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L640) |  | GET | `/products/volume-summary` |
+| [getProduct()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L649) |  | GET | `/products/{product_id}` |
+| [getProductBook()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L660) |  | GET | `/products/{product_id}/book` |
+| [getProductCandles()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L671) |  | GET | `/products/{product_id}/candles` |
+| [getProductStats()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L681) |  | GET | `/products/{product_id}/stats` |
+| [getProductTicker()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L690) |  | GET | `/products/{product_id}/ticker` |
+| [getProductTrades()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L699) |  | GET | `/products/{product_id}/trades` |
+| [getProfiles()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L715) | :closed_lock_with_key:  | GET | `/profiles` |
+| [createProfile()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L724) | :closed_lock_with_key:  | POST | `/profiles` |
+| [transferFundsBetweenProfiles()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L733) | :closed_lock_with_key:  | POST | `/profiles/transfer` |
+| [getProfileById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L744) | :closed_lock_with_key:  | GET | `/profiles/{profile_id}` |
+| [renameProfile()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L757) | :closed_lock_with_key:  | PUT | `/profiles/{profile_id}` |
+| [deleteProfile()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L768) | :closed_lock_with_key:  | PUT | `/profiles/{profile_id}/deactivate` |
+| [getAllReports()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L786) | :closed_lock_with_key:  | GET | `/reports` |
+| [createReport()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L796) | :closed_lock_with_key:  | POST | `/reports` |
+| [getReport()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L805) | :closed_lock_with_key:  | GET | `/reports/{report_id}` |
+| [getTravelRuleInformation()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L820) | :closed_lock_with_key:  | GET | `/travel-rules` |
+| [createTravelRuleEntry()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L831) | :closed_lock_with_key:  | POST | `/travel-rules` |
+| [deleteTravelRuleEntry()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L844) | :closed_lock_with_key:  | DELETE | `/travel-rules/{id}` |
+| [getUserExchangeLimits()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L859) | :closed_lock_with_key:  | GET | `/users/{user_id}/exchange-limits` |
+| [updateSettlementPreference()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L868) | :closed_lock_with_key:  | POST | `/users/{user_id}/settlement-preferences` |
+| [getUserTradingVolume()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L883) | :closed_lock_with_key:  | GET | `/users/{user_id}/trading-volumes` |
+| [getAllWrappedAssets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L898) |  | GET | `/wrapped-assets` |
+| [getAllStakeWraps()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L907) | :closed_lock_with_key:  | GET | `/wrapped-assets/stake-wrap` |
+| [createStakeWrap()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L916) | :closed_lock_with_key:  | POST | `/wrapped-assets/stake-wrap` |
+| [getStakeWrap()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L929) | :closed_lock_with_key:  | GET | `/wrapped-assets/stake-wrap/{stake_wrap_id}` |
+| [getWrappedAssetDetails()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L940) | :closed_lock_with_key:  | GET | `/wrapped-assets/{wrapped_asset_id}` |
+| [getWrappedAssetConversionRate()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBExchangeClient.ts#L949) | :closed_lock_with_key:  | GET | `/wrapped-assets/{wrapped_asset_id}/conversion-rate` |
 
 # CBInternationalClient.ts
 
@@ -227,64 +227,64 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAssets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L56) |  | GET | `/api/v1/assets` |
-| [getAssetDetails()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L65) |  | GET | `/api/v1/assets/{asset}` |
-| [getSupportedNetworksPerAsset()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L74) |  | GET | `/api/v1/assets/{asset}/networks` |
-| [getIndexComposition()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L89) |  | GET | `/api/v1/index/{index}/composition` |
-| [getIndexCompositionHistory()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L99) |  | GET | `/api/v1/index/{index}/composition-history` |
-| [getIndexPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L111) |  | GET | `/api/v1/index/{index}/price` |
-| [getIndexCandles()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L121) |  | GET | `/api/v1/index/{index}/candles` |
-| [getInstruments()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L137) |  | GET | `/api/v1/instruments` |
-| [getInstrumentDetails()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L146) |  | GET | `/api/v1/instruments/{instrument}` |
-| [getQuotePerInstrument()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L155) |  | GET | `/api/v1/instruments/{instrument}/quote` |
-| [getDailyTradingVolumes()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L164) |  | GET | `/api/v1/instruments/volumes/daily` |
-| [getAggregatedCandlesData()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L173) |  | GET | `/api/v1/instruments/{instrument}/candles` |
-| [getHistoricalFundingRates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L183) |  | GET | `/api/v1/instruments/{instrument}/funding` |
-| [getPositionOffsets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L203) |  | GET | `/api/v1/position-offsets` |
-| [submitOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L218) | :closed_lock_with_key:  | POST | `/api/v1/orders` |
-| [getOpenOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L229) | :closed_lock_with_key:  | GET | `/api/v1/orders` |
-| [cancelOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L238) | :closed_lock_with_key:  | DELETE | `/api/v1/orders` |
-| [updateOpenOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L247) | :closed_lock_with_key:  | PUT | `/api/v1/orders/{id}` |
-| [getOrderDetails()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L257) | :closed_lock_with_key:  | GET | `/api/v1/orders/{id}` |
-| [cancelOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L267) | :closed_lock_with_key:  | DELETE | `/api/v1/orders/{id}` |
-| [getUserPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L285) | :closed_lock_with_key:  | GET | `/api/v1/portfolios` |
-| [createPortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L294) | :closed_lock_with_key:  | POST | `/api/v1/portfolios` |
-| [updatePortfolioParameters()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L303) | :closed_lock_with_key:  | PATCH | `/api/v1/portfolios` |
-| [getUserPortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L314) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}` |
-| [updatePortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L323) | :closed_lock_with_key:  | PUT | `/api/v1/portfolios/{portfolio}` |
-| [getPortfolioDetails()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L333) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/detail` |
-| [getPortfolioSummary()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L342) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/summary` |
-| [getPortfolioBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L351) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/balances` |
-| [getBalanceForPortfolioAsset()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L360) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/balances/{asset}` |
-| [getActiveLoansForPortfolio()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L374) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/loans` |
-| [getLoanInfoForPortfolioAsset()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L383) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/loans/{asset}` |
-| [acquireOrRepayLoan()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L397) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/loans/{asset}` |
-| [previewLoanUpdate()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L414) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/loans/{asset}/preview` |
-| [getMaxLoanAvailability()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L432) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/loans/{asset}/availability` |
-| [getPortfolioPositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L446) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/positions` |
-| [getPositionForPortfolioInstrument()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L455) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/positions/{instrument}` |
-| [getTotalOpenPositionLimit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L469) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/position-limits` |
-| [getOpenPositionLimitsForAllInstruments()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L480) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/position-limits/positions` |
-| [getOpenPositionLimitsForInstrument()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L493) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/position-limits/positions/{instrument}` |
-| [getFillsByPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L508) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/fills` |
-| [getPortfolioFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L517) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/fills` |
-| [setCrossCollateral()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L527) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/cross-collateral-enabled` |
-| [setAutoMargin()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L544) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/auto-margin-enabled` |
-| [setPortfolioMarginOverride()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L557) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/margin` |
-| [getFundTransferLimit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L570) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/transfer/{portfolio}/{asset}/transfer-limit` |
-| [transferFundsBetweenPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L585) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/transfer` |
-| [transferPositionsBetweenPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L597) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/transfer-position` |
-| [getPortfolioFeeRates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L610) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/fee-rates` |
-| [getRankings()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L624) | :closed_lock_with_key:  | GET | `/api/v1/rankings/statistics` |
-| [getMatchingTransfers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L643) | :closed_lock_with_key:  | GET | `/api/v1/transfers` |
-| [getTransfer()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L652) | :closed_lock_with_key:  | GET | `/api/v1/transfers/{transfer_uuid}` |
-| [withdrawToCryptoAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L661) | :closed_lock_with_key:  | POST | `/api/v1/transfers/withdraw` |
-| [createCryptoAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L672) | :closed_lock_with_key:  | POST | `/api/v1/transfers/address` |
-| [createCounterpartyId()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L685) | :closed_lock_with_key:  | POST | `/api/v1/transfers/create-counterparty-id` |
-| [validateCounterpartyId()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L696) | :closed_lock_with_key:  | POST | `/api/v1/transfers/validate-counterparty-id` |
-| [getCounterpartyWithdrawalLimit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L708) | :closed_lock_with_key:  | GET | `/api/v1/transfers/withdraw/{portfolio}/{asset}/counterparty-withdrawal-limit` |
-| [withdrawToCounterpartyId()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L723) | :closed_lock_with_key:  | POST | `/api/v1/transfers/withdraw/counterparty` |
-| [getFeeRateTiers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBInternationalClient.ts#L741) | :closed_lock_with_key:  | GET | `/api/v1/fee-rate-tiers` |
+| [getAssets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L56) |  | GET | `/api/v1/assets` |
+| [getAssetDetails()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L65) |  | GET | `/api/v1/assets/{asset}` |
+| [getSupportedNetworksPerAsset()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L74) |  | GET | `/api/v1/assets/{asset}/networks` |
+| [getIndexComposition()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L89) |  | GET | `/api/v1/index/{index}/composition` |
+| [getIndexCompositionHistory()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L99) |  | GET | `/api/v1/index/{index}/composition-history` |
+| [getIndexPrice()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L111) |  | GET | `/api/v1/index/{index}/price` |
+| [getIndexCandles()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L121) |  | GET | `/api/v1/index/{index}/candles` |
+| [getInstruments()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L137) |  | GET | `/api/v1/instruments` |
+| [getInstrumentDetails()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L146) |  | GET | `/api/v1/instruments/{instrument}` |
+| [getQuotePerInstrument()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L155) |  | GET | `/api/v1/instruments/{instrument}/quote` |
+| [getDailyTradingVolumes()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L164) |  | GET | `/api/v1/instruments/volumes/daily` |
+| [getAggregatedCandlesData()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L173) |  | GET | `/api/v1/instruments/{instrument}/candles` |
+| [getHistoricalFundingRates()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L183) |  | GET | `/api/v1/instruments/{instrument}/funding` |
+| [getPositionOffsets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L203) |  | GET | `/api/v1/position-offsets` |
+| [submitOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L218) | :closed_lock_with_key:  | POST | `/api/v1/orders` |
+| [getOpenOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L229) | :closed_lock_with_key:  | GET | `/api/v1/orders` |
+| [cancelOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L238) | :closed_lock_with_key:  | DELETE | `/api/v1/orders` |
+| [updateOpenOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L247) | :closed_lock_with_key:  | PUT | `/api/v1/orders/{id}` |
+| [getOrderDetails()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L257) | :closed_lock_with_key:  | GET | `/api/v1/orders/{id}` |
+| [cancelOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L267) | :closed_lock_with_key:  | DELETE | `/api/v1/orders/{id}` |
+| [getUserPortfolios()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L285) | :closed_lock_with_key:  | GET | `/api/v1/portfolios` |
+| [createPortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L294) | :closed_lock_with_key:  | POST | `/api/v1/portfolios` |
+| [updatePortfolioParameters()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L303) | :closed_lock_with_key:  | PATCH | `/api/v1/portfolios` |
+| [getUserPortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L314) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}` |
+| [updatePortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L323) | :closed_lock_with_key:  | PUT | `/api/v1/portfolios/{portfolio}` |
+| [getPortfolioDetails()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L333) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/detail` |
+| [getPortfolioSummary()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L342) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/summary` |
+| [getPortfolioBalances()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L351) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/balances` |
+| [getBalanceForPortfolioAsset()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L360) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/balances/{asset}` |
+| [getActiveLoansForPortfolio()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L374) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/loans` |
+| [getLoanInfoForPortfolioAsset()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L383) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/loans/{asset}` |
+| [acquireOrRepayLoan()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L397) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/loans/{asset}` |
+| [previewLoanUpdate()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L414) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/loans/{asset}/preview` |
+| [getMaxLoanAvailability()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L432) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/loans/{asset}/availability` |
+| [getPortfolioPositions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L446) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/positions` |
+| [getPositionForPortfolioInstrument()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L455) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/positions/{instrument}` |
+| [getTotalOpenPositionLimit()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L469) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/position-limits` |
+| [getOpenPositionLimitsForAllInstruments()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L480) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/position-limits/positions` |
+| [getOpenPositionLimitsForInstrument()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L493) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/position-limits/positions/{instrument}` |
+| [getFillsByPortfolios()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L508) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/fills` |
+| [getPortfolioFills()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L517) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/{portfolio}/fills` |
+| [setCrossCollateral()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L527) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/cross-collateral-enabled` |
+| [setAutoMargin()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L544) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/{portfolio}/auto-margin-enabled` |
+| [setPortfolioMarginOverride()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L557) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/margin` |
+| [getFundTransferLimit()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L570) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/transfer/{portfolio}/{asset}/transfer-limit` |
+| [transferFundsBetweenPortfolios()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L585) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/transfer` |
+| [transferPositionsBetweenPortfolios()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L597) | :closed_lock_with_key:  | POST | `/api/v1/portfolios/transfer-position` |
+| [getPortfolioFeeRates()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L610) | :closed_lock_with_key:  | GET | `/api/v1/portfolios/fee-rates` |
+| [getRankings()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L624) | :closed_lock_with_key:  | GET | `/api/v1/rankings/statistics` |
+| [getMatchingTransfers()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L643) | :closed_lock_with_key:  | GET | `/api/v1/transfers` |
+| [getTransfer()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L652) | :closed_lock_with_key:  | GET | `/api/v1/transfers/{transfer_uuid}` |
+| [withdrawToCryptoAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L661) | :closed_lock_with_key:  | POST | `/api/v1/transfers/withdraw` |
+| [createCryptoAddress()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L672) | :closed_lock_with_key:  | POST | `/api/v1/transfers/address` |
+| [createCounterpartyId()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L685) | :closed_lock_with_key:  | POST | `/api/v1/transfers/create-counterparty-id` |
+| [validateCounterpartyId()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L696) | :closed_lock_with_key:  | POST | `/api/v1/transfers/validate-counterparty-id` |
+| [getCounterpartyWithdrawalLimit()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L708) | :closed_lock_with_key:  | GET | `/api/v1/transfers/withdraw/{portfolio}/{asset}/counterparty-withdrawal-limit` |
+| [withdrawToCounterpartyId()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L723) | :closed_lock_with_key:  | POST | `/api/v1/transfers/withdraw/counterparty` |
+| [getFeeRateTiers()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBInternationalClient.ts#L741) | :closed_lock_with_key:  | GET | `/api/v1/fee-rate-tiers` |
 
 # CBPrimeClient.ts
 
@@ -292,64 +292,64 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getActivities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L79) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities` |
-| [getActivityById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L89) | :closed_lock_with_key:  | GET | `/v1/activities/{activity_id}` |
-| [getEntityActivities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L99) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/activities` |
-| [getPortfolioActivityById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L109) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities/{activity_id}` |
-| [createPortfolioAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L130) | :closed_lock_with_key:  | POST | `/v1/allocations` |
-| [createPortfolioNetAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L141) | :closed_lock_with_key:  | POST | `/v1/allocations/net` |
-| [getPortfolioAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L152) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations` |
-| [getAllocationById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L164) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/{allocation_id}` |
-| [getNetAllocationsByNettingId()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L179) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/net/{netting_id}` |
-| [getEntityAccruals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L200) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/accruals` |
-| [getEntityLocateAvailabilities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L210) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/locates_availability` |
-| [getEntityMargin()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L225) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin` |
-| [getEntityMarginSummaries()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L235) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin_summaries` |
-| [getEntityTFTieredFees()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L247) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/tf_tiered_fees` |
-| [getPortfolioAccruals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L259) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/accruals` |
-| [getPortfolioBuyingPower()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L269) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/buying_power` |
-| [getPortfolioLocates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L284) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/locates` |
-| [getPortfolioMarginConversions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L295) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/margin_conversions` |
-| [getPortfolioWithdrawalPower()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L310) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/withdrawal_power` |
-| [getInvoices()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L331) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/invoices` |
-| [getEntityAggregatePositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L347) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/aggregate_positions` |
-| [getEntityPositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L364) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/positions` |
-| [getAssets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L384) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/assets` |
-| [getEntityPaymentMethods()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L399) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods` |
-| [getEntityPaymentMethod()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L408) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods/{payment_method_id}` |
-| [getUsers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L429) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/users` |
-| [getPortfolioUsers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L439) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/users` |
-| [getPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L455) | :closed_lock_with_key:  | GET | `/v1/portfolios` |
-| [getPortfolioById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L464) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}` |
-| [getPortfolioCreditInformation()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L473) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/credit` |
-| [getAddressBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L490) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/address_book` |
-| [createAddressBookEntry()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L503) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/address_book` |
-| [getPortfolioBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L523) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/balances` |
-| [getWalletBalance()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L537) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/balance` |
-| [getWeb3WalletBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L552) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/web3_balances` |
-| [getPortfolioCommission()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L573) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/commission` |
-| [getPortfolioFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L591) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/fills` |
-| [getOpenOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L601) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/open_orders` |
-| [submitOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L611) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order` |
-| [getOrderPreview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L624) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order_preview` |
-| [getPortfolioOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L636) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders` |
-| [getOrderById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L646) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}` |
-| [cancelOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L659) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/orders/{order_id}/cancel` |
-| [getOrderFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L674) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}/fills` |
-| [editOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L687) | :closed_lock_with_key:  | PUT | `/v1/portfolios/{portfolio_id}/orders/{order_id}/edit` |
-| [rotateApiKey()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L701) | :closed_lock_with_key:  | POST | `/v1/api-keys/rotate` |
-| [getPortfolioProducts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L716) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/products` |
-| [getPortfolioTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L732) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions` |
-| [getTransactionById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L747) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}` |
-| [getTransactionTravelRuleData()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L768) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}/travel_rule` |
-| [createConversion()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L782) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/conversion` |
-| [getWalletTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L795) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transactions` |
-| [createTransfer()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L810) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transfers` |
-| [createWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L823) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/withdrawals` |
-| [getPortfolioWallets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L842) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets` |
-| [createWallet()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L852) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets` |
-| [getWalletById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L864) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}` |
-| [getWalletDepositInstructions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L879) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/deposit_instructions` |
+| [getActivities()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L78) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities` |
+| [getActivityById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L88) | :closed_lock_with_key:  | GET | `/v1/activities/{activity_id}` |
+| [getEntityActivities()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L98) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/activities` |
+| [getPortfolioActivityById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L108) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities/{activity_id}` |
+| [createPortfolioAllocations()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L129) | :closed_lock_with_key:  | POST | `/v1/allocations` |
+| [createPortfolioNetAllocations()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L140) | :closed_lock_with_key:  | POST | `/v1/allocations/net` |
+| [getPortfolioAllocations()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L151) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations` |
+| [getAllocationById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L163) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/{allocation_id}` |
+| [getNetAllocationsByNettingId()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L178) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/net/{netting_id}` |
+| [getEntityAccruals()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L199) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/accruals` |
+| [getEntityLocateAvailabilities()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L209) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/locates_availability` |
+| [getEntityMargin()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L224) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin` |
+| [getEntityMarginSummaries()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L234) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin_summaries` |
+| [getEntityTFTieredFees()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L246) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/tf_tiered_fees` |
+| [getPortfolioAccruals()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L258) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/accruals` |
+| [getPortfolioBuyingPower()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L268) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/buying_power` |
+| [getPortfolioLocates()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L283) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/locates` |
+| [getPortfolioMarginConversions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L294) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/margin_conversions` |
+| [getPortfolioWithdrawalPower()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L309) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/withdrawal_power` |
+| [getInvoices()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L330) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/invoices` |
+| [getEntityAggregatePositions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L346) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/aggregate_positions` |
+| [getEntityPositions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L363) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/positions` |
+| [getAssets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L383) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/assets` |
+| [getEntityPaymentMethods()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L398) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods` |
+| [getEntityPaymentMethod()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L407) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods/{payment_method_id}` |
+| [getUsers()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L428) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/users` |
+| [getPortfolioUsers()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L438) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/users` |
+| [getPortfolios()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L454) | :closed_lock_with_key:  | GET | `/v1/portfolios` |
+| [getPortfolioById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L463) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}` |
+| [getPortfolioCreditInformation()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L472) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/credit` |
+| [getAddressBook()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L489) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/address_book` |
+| [createAddressBookEntry()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L502) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/address_book` |
+| [getPortfolioBalances()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L522) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/balances` |
+| [getWalletBalance()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L536) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/balance` |
+| [getWeb3WalletBalances()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L551) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/web3_balances` |
+| [getPortfolioCommission()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L572) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/commission` |
+| [getPortfolioFills()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L590) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/fills` |
+| [getOpenOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L600) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/open_orders` |
+| [submitOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L610) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order` |
+| [getOrderPreview()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L623) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order_preview` |
+| [getPortfolioOrders()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L635) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders` |
+| [getOrderById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L645) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}` |
+| [cancelOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L658) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/orders/{order_id}/cancel` |
+| [getOrderFills()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L673) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}/fills` |
+| [editOrder()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L686) | :closed_lock_with_key:  | PUT | `/v1/portfolios/{portfolio_id}/orders/{order_id}/edit` |
+| [rotateApiKey()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L700) | :closed_lock_with_key:  | POST | `/v1/api-keys/rotate` |
+| [getPortfolioProducts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L715) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/products` |
+| [getPortfolioTransactions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L731) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions` |
+| [getTransactionById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L746) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}` |
+| [getTransactionTravelRuleData()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L767) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}/travel_rule` |
+| [createConversion()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L781) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/conversion` |
+| [getWalletTransactions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L794) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transactions` |
+| [createTransfer()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L809) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transfers` |
+| [createWithdrawal()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L822) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/withdrawals` |
+| [getPortfolioWallets()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L841) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets` |
+| [createWallet()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L851) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets` |
+| [getWalletById()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L863) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}` |
+| [getWalletDepositInstructions()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBPrimeClient.ts#L878) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/deposit_instructions` |
 
 # CBCommerceClient.ts
 
@@ -357,11 +357,11 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [createCharge()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L38) | :closed_lock_with_key:  | POST | `/charges` |
-| [getAllCharges()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L63) | :closed_lock_with_key:  | GET | `/charges` |
-| [getCharge()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L72) | :closed_lock_with_key:  | GET | `/charges/{charge_code_or_charge_id}` |
-| [createCheckout()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L87) | :closed_lock_with_key:  | POST | `/checkouts` |
-| [getAllCheckouts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L110) | :closed_lock_with_key:  | GET | `/checkouts` |
-| [getCheckout()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L119) | :closed_lock_with_key:  | GET | `/checkouts/{checkout_id}` |
-| [listEvents()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L134) | :closed_lock_with_key:  | GET | `/events` |
-| [showEvent()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBCommerceClient.ts#L145) | :closed_lock_with_key:  | GET | `/events/{event_id}` |
+| [createCharge()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L38) | :closed_lock_with_key:  | POST | `/charges` |
+| [getAllCharges()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L63) | :closed_lock_with_key:  | GET | `/charges` |
+| [getCharge()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L72) | :closed_lock_with_key:  | GET | `/charges/{charge_code_or_charge_id}` |
+| [createCheckout()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L87) | :closed_lock_with_key:  | POST | `/checkouts` |
+| [getAllCheckouts()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L110) | :closed_lock_with_key:  | GET | `/checkouts` |
+| [getCheckout()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L119) | :closed_lock_with_key:  | GET | `/checkouts/{checkout_id}` |
+| [listEvents()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L134) | :closed_lock_with_key:  | GET | `/events` |
+| [showEvent()](https://github.com/sieblyio/coinbase-api/blob/master/src/CBCommerceClient.ts#L145) | :closed_lock_with_key:  | GET | `/events/{event_id}` |

--- a/docs/endpointFunctionList.md
+++ b/docs/endpointFunctionList.md
@@ -110,31 +110,32 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getAccounts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L66) | :closed_lock_with_key:  | GET | `/v2/accounts` |
-| [getAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L85) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}` |
-| [createAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L102) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/addresses` |
-| [getAddresses()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L118) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses` |
-| [getAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L144) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}` |
-| [getAddressTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L161) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}/transactions` |
-| [sendMoney()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L197) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
-| [transferMoney()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L212) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
-| [getTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L229) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions` |
-| [getTransaction()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L255) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions/{transactionId}` |
-| [depositFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L277) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits` |
-| [commitDeposit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L289) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits/{deposit_id}/commit` |
-| [getDeposits()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L306) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits` |
-| [getDeposit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L326) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits/{deposit_id}` |
-| [withdrawFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L345) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals` |
-| [commitWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L357) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}/commit` |
-| [getWithdrawals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L374) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals` |
-| [getWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L400) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}` |
-| [getFiatCurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L423) |  | GET | `/v2/currencies` |
-| [getCryptocurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L434) |  | GET | `/v2/currencies/crypto` |
-| [getExchangeRates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L450) |  | GET | `/v2/exchange-rates` |
-| [getBuyPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L471) |  | GET | `/v2/prices/{currencyPair}/buy` |
-| [getSellPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L486) |  | GET | `/v2/prices/{currencyPair}/sell` |
-| [getSpotPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L501) |  | GET | `/v2/prices/{currencyPair}/spot` |
-| [getCurrentTime()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L523) |  | GET | `/v2/time` |
+| [getAccounts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L67) | :closed_lock_with_key:  | GET | `/v2/accounts` |
+| [getAccount()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L86) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}` |
+| [createAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L103) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/addresses` |
+| [getAddresses()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L119) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses` |
+| [getAddress()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L145) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}` |
+| [getAddressTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L162) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/addresses/{addressId}/transactions` |
+| [sendMoney()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L198) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
+| [transferMoney()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L213) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/transactions` |
+| [getTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L230) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions` |
+| [getTransaction()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L256) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/transactions/{transactionId}` |
+| [depositFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L278) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits` |
+| [commitDeposit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L290) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/deposits/{deposit_id}/commit` |
+| [getDeposits()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L307) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits` |
+| [getDeposit()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L327) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/deposits/{deposit_id}` |
+| [withdrawFunds()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L346) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals` |
+| [commitWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L358) | :closed_lock_with_key:  | POST | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}/commit` |
+| [getWithdrawals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L375) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals` |
+| [getWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L401) | :closed_lock_with_key:  | GET | `/v2/accounts/{account_id}/withdrawals/{withdrawal_id}` |
+| [getCoinbaseOneSubscription()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L424) | :closed_lock_with_key:  | GET | `/v2/subscriptions/coinbase-one` |
+| [getFiatCurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L442) |  | GET | `/v2/currencies` |
+| [getCryptocurrencies()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L453) |  | GET | `/v2/currencies/crypto` |
+| [getExchangeRates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L469) |  | GET | `/v2/exchange-rates` |
+| [getBuyPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L490) |  | GET | `/v2/prices/{currencyPair}/buy` |
+| [getSellPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L505) |  | GET | `/v2/prices/{currencyPair}/sell` |
+| [getSpotPrice()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L520) |  | GET | `/v2/prices/{currencyPair}/spot` |
+| [getCurrentTime()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBAppClient.ts#L542) |  | GET | `/v2/time` |
 
 # CBExchangeClient.ts
 
@@ -291,63 +292,64 @@ This table includes all endpoints from the official Exchange API docs and corres
 
 | Function | AUTH | HTTP Method | Endpoint |
 | -------- | :------: | :------: | -------- |
-| [getActivities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L77) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities` |
-| [getActivityById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L87) | :closed_lock_with_key:  | GET | `/v1/activities/{activity_id}` |
-| [getEntityActivities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L97) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/activities` |
-| [getPortfolioActivityById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L107) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities/{activity_id}` |
-| [createPortfolioAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L128) | :closed_lock_with_key:  | POST | `/v1/allocations` |
-| [createPortfolioNetAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L139) | :closed_lock_with_key:  | POST | `/v1/allocations/net` |
-| [getPortfolioAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L150) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations` |
-| [getAllocationById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L162) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/{allocation_id}` |
-| [getNetAllocationsByNettingId()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L177) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/net/{netting_id}` |
-| [getEntityAccruals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L198) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/accruals` |
-| [getEntityLocateAvailabilities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L208) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/locates_availability` |
-| [getEntityMargin()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L223) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin` |
-| [getEntityMarginSummaries()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L233) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin_summaries` |
-| [getEntityTFTieredFees()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L245) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/tf_tiered_fees` |
-| [getPortfolioAccruals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L257) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/accruals` |
-| [getPortfolioBuyingPower()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L267) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/buying_power` |
-| [getPortfolioLocates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L282) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/locates` |
-| [getPortfolioMarginConversions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L293) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/margin_conversions` |
-| [getPortfolioWithdrawalPower()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L308) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/withdrawal_power` |
-| [getInvoices()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L329) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/invoices` |
-| [getEntityAggregatePositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L345) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/aggregate_positions` |
-| [getEntityPositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L362) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/positions` |
-| [getAssets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L382) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/assets` |
-| [getEntityPaymentMethods()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L397) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods` |
-| [getEntityPaymentMethod()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L406) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods/{payment_method_id}` |
-| [getUsers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L427) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/users` |
-| [getPortfolioUsers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L437) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/users` |
-| [getPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L453) | :closed_lock_with_key:  | GET | `/v1/portfolios` |
-| [getPortfolioById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L462) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}` |
-| [getPortfolioCreditInformation()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L471) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/credit` |
-| [getAddressBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L488) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/address_book` |
-| [createAddressBookEntry()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L501) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/address_book` |
-| [getPortfolioBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L521) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/balances` |
-| [getWalletBalance()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L535) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/balance` |
-| [getWeb3WalletBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L550) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/web3_balances` |
-| [getPortfolioCommission()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L571) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/commission` |
-| [getPortfolioFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L589) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/fills` |
-| [getOpenOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L599) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/open_orders` |
-| [submitOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L609) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order` |
-| [getOrderPreview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L622) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order_preview` |
-| [getPortfolioOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L634) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders` |
-| [getOrderById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L644) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}` |
-| [cancelOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L657) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/orders/{order_id}/cancel` |
-| [getOrderFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L672) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}/fills` |
-| [editOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L685) | :closed_lock_with_key:  | PUT | `/v1/portfolios/{portfolio_id}/orders/{order_id}/edit` |
-| [rotateApiKey()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L699) | :closed_lock_with_key:  | POST | `/v1/api-keys/rotate` |
-| [getPortfolioProducts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L714) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/products` |
-| [getPortfolioTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L730) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions` |
-| [getTransactionById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L745) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}` |
-| [createConversion()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L760) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/conversion` |
-| [getWalletTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L773) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transactions` |
-| [createTransfer()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L788) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transfers` |
-| [createWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L801) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/withdrawals` |
-| [getPortfolioWallets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L820) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets` |
-| [createWallet()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L830) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets` |
-| [getWalletById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L842) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}` |
-| [getWalletDepositInstructions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L857) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/deposit_instructions` |
+| [getActivities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L79) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities` |
+| [getActivityById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L89) | :closed_lock_with_key:  | GET | `/v1/activities/{activity_id}` |
+| [getEntityActivities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L99) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/activities` |
+| [getPortfolioActivityById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L109) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/activities/{activity_id}` |
+| [createPortfolioAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L130) | :closed_lock_with_key:  | POST | `/v1/allocations` |
+| [createPortfolioNetAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L141) | :closed_lock_with_key:  | POST | `/v1/allocations/net` |
+| [getPortfolioAllocations()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L152) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations` |
+| [getAllocationById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L164) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/{allocation_id}` |
+| [getNetAllocationsByNettingId()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L179) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/allocations/net/{netting_id}` |
+| [getEntityAccruals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L200) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/accruals` |
+| [getEntityLocateAvailabilities()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L210) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/locates_availability` |
+| [getEntityMargin()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L225) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin` |
+| [getEntityMarginSummaries()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L235) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/margin_summaries` |
+| [getEntityTFTieredFees()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L247) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/tf_tiered_fees` |
+| [getPortfolioAccruals()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L259) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/accruals` |
+| [getPortfolioBuyingPower()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L269) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/buying_power` |
+| [getPortfolioLocates()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L284) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/locates` |
+| [getPortfolioMarginConversions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L295) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/margin_conversions` |
+| [getPortfolioWithdrawalPower()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L310) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/withdrawal_power` |
+| [getInvoices()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L331) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/invoices` |
+| [getEntityAggregatePositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L347) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/aggregate_positions` |
+| [getEntityPositions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L364) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/positions` |
+| [getAssets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L384) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/assets` |
+| [getEntityPaymentMethods()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L399) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods` |
+| [getEntityPaymentMethod()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L408) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/payment-methods/{payment_method_id}` |
+| [getUsers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L429) | :closed_lock_with_key:  | GET | `/v1/entities/{entity_id}/users` |
+| [getPortfolioUsers()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L439) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/users` |
+| [getPortfolios()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L455) | :closed_lock_with_key:  | GET | `/v1/portfolios` |
+| [getPortfolioById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L464) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}` |
+| [getPortfolioCreditInformation()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L473) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/credit` |
+| [getAddressBook()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L490) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/address_book` |
+| [createAddressBookEntry()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L503) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/address_book` |
+| [getPortfolioBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L523) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/balances` |
+| [getWalletBalance()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L537) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/balance` |
+| [getWeb3WalletBalances()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L552) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/web3_balances` |
+| [getPortfolioCommission()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L573) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/commission` |
+| [getPortfolioFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L591) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/fills` |
+| [getOpenOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L601) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/open_orders` |
+| [submitOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L611) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order` |
+| [getOrderPreview()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L624) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/order_preview` |
+| [getPortfolioOrders()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L636) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders` |
+| [getOrderById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L646) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}` |
+| [cancelOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L659) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/orders/{order_id}/cancel` |
+| [getOrderFills()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L674) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/orders/{order_id}/fills` |
+| [editOrder()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L687) | :closed_lock_with_key:  | PUT | `/v1/portfolios/{portfolio_id}/orders/{order_id}/edit` |
+| [rotateApiKey()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L701) | :closed_lock_with_key:  | POST | `/v1/api-keys/rotate` |
+| [getPortfolioProducts()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L716) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/products` |
+| [getPortfolioTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L732) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions` |
+| [getTransactionById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L747) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}` |
+| [getTransactionTravelRuleData()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L768) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/transactions/{transaction_id}/travel_rule` |
+| [createConversion()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L782) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/conversion` |
+| [getWalletTransactions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L795) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transactions` |
+| [createTransfer()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L810) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/transfers` |
+| [createWithdrawal()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L823) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/withdrawals` |
+| [getPortfolioWallets()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L842) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets` |
+| [createWallet()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L852) | :closed_lock_with_key:  | POST | `/v1/portfolios/{portfolio_id}/wallets` |
+| [getWalletById()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L864) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}` |
+| [getWalletDepositInstructions()](https://github.com/tiagosiebler/coinbase-api/blob/master/src/CBPrimeClient.ts#L879) | :closed_lock_with_key:  | GET | `/v1/portfolios/{portfolio_id}/wallets/{wallet_id}/deposit_instructions` |
 
 # CBCommerceClient.ts
 

--- a/examples/apidoc/CBAppClient/getCoinbaseOneSubscription.js
+++ b/examples/apidoc/CBAppClient/getCoinbaseOneSubscription.js
@@ -1,0 +1,22 @@
+import { CBAppClient } from 'coinbase-api';
+// or, if require is preferred:
+// const { CBAppClient } = require('coinbase-api');
+
+// This example shows how to call this coinbase API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "coinbase-api" for coinbase exchange
+// This coinbase API SDK is available on npm via "npm install coinbase-api"
+// ENDPOINT: /v2/subscriptions/coinbase-one
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new CBAppClient({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+});
+
+client.getCoinbaseOneSubscription(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/examples/apidoc/CBPrimeClient/getTransactionTravelRuleData.js
+++ b/examples/apidoc/CBPrimeClient/getTransactionTravelRuleData.js
@@ -1,0 +1,22 @@
+import { CBPrimeClient } from 'coinbase-api';
+// or, if require is preferred:
+// const { CBPrimeClient } = require('coinbase-api');
+
+// This example shows how to call this coinbase API endpoint with either node.js, javascript (js) or typescript (ts) with the npm module "coinbase-api" for coinbase exchange
+// This coinbase API SDK is available on npm via "npm install coinbase-api"
+// ENDPOINT: /v1/portfolios/{portfolio_id}/transactions/{transaction_id}/travel_rule
+// METHOD: GET
+// PUBLIC: NO
+
+const client = new CBPrimeClient({
+  apiKey: 'insert_api_key_here',
+  apiSecret: 'insert_api_secret_here',
+});
+
+client.getTransactionTravelRuleData(params)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.error(error);
+  });

--- a/llms.txt
+++ b/llms.txt
@@ -1450,309 +1450,6 @@ export interface CBAppWithdrawFundsRequest {
  */
 
 ================
-File: src/types/response/coinbase-app-client.ts
-================
-export interface CBAppPagination {
-  ending_before?: string | null;
-  starting_after?: string | null;
-  limit?: number;
-  order?: string;
-  previous_uri: string | null;
-  next_uri: string | null;
-}
-⋮----
-/**
- *
- * Account Endpoints
- *
- */
-⋮----
-interface AccountCurrency {
-  address_regex: string;
-  asset_id: string;
-  code: string;
-  color: string;
-  exponent: number;
-  name: string;
-  slug: string;
-  sort_index: number;
-  type: string;
-}
-⋮----
-interface AccountBalance {
-  amount: string;
-  currency: string;
-}
-⋮----
-export interface CBAppAccount {
-  id: string;
-  name: string;
-  primary: boolean;
-  type: string;
-  currency: AccountCurrency;
-  balance: AccountBalance;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-  ready: boolean;
-}
-⋮----
-/**
- *
- * Address Endpoints
- *
- */
-⋮----
-export interface CBAppAddress {
-  id: string;
-  address: string;
-  name?: string;
-  network: string;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-}
-⋮----
-/**
- *
- * Transactions Endpoints
- *
- */
-⋮----
-interface TransactionAmount {
-  amount: string;
-  currency: string;
-}
-⋮----
-interface TransactionNetwork {
-  status: string;
-  name: string;
-  hash?: string;
-  transaction_fee?: TransactionAmount;
-  transaction_amount?: TransactionAmount;
-  network_name?: string;
-  status_description?: string | null;
-}
-⋮----
-interface TransactionFrom {
-  id: string;
-  resource: string;
-  resource_path?: string;
-}
-⋮----
-interface TransactionTo {
-  resource: string;
-  address?: string;
-  email?: string;
-  id?: string;
-  resource_path?: string;
-}
-⋮----
-interface TransactionDetails {
-  title: string;
-  subtitle: string;
-  header?: string;
-  health?: string;
-  subsidebar_label?: string | null;
-}
-⋮----
-interface AdvancedTradeFill {
-  fill_price: string;
-  product_id: string;
-  order_id: string;
-  commission: string;
-  order_side: 'BUY' | 'SELL';
-}
-⋮----
-export interface CBAppTransaction {
-  id: string;
-  type: string;
-  status: string;
-  amount: TransactionAmount;
-  native_amount: TransactionAmount;
-  description: string | null;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-  network?: TransactionNetwork;
-  from?: TransactionFrom;
-  to?: TransactionTo;
-  details?: TransactionDetails;
-  instant_exchange?: boolean;
-  advanced_trade_fill?: AdvancedTradeFill;
-  cancelable?: boolean;
-  idem?: string;
-}
-⋮----
-/**
- *
- * Deposits/Withdrawal Endpoints
- *
- */
-⋮----
-interface DepositWithdrawalPaymentMethod {
-  id: string;
-  resource: string;
-  resource_path: string;
-}
-⋮----
-interface DepositWithdrawalTransaction {
-  id: string;
-  resource: string;
-  resource_path: string;
-}
-⋮----
-interface DepositWithdrawalAmountCurrency {
-  amount: string;
-  currency: string;
-}
-⋮----
-export interface CBAppDepositWithdrawal {
-  id: string;
-  status: string;
-  payment_method: DepositWithdrawalPaymentMethod;
-  transaction: DepositWithdrawalTransaction;
-  amount: DepositWithdrawalAmountCurrency;
-  subtotal: DepositWithdrawalAmountCurrency;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-  committed: boolean;
-  fee: DepositWithdrawalAmountCurrency;
-  payout_at: string;
-}
-⋮----
-interface TransferAmount {
-  value: string;
-  currency: string;
-}
-⋮----
-interface TransferOwner {
-  id: string;
-  uuid: string;
-  user_uuid: string;
-  type: string;
-}
-⋮----
-interface TransferLedgerAccount {
-  account_id: string;
-  currency: string;
-  owner: TransferOwner;
-}
-⋮----
-interface TransferExternalPaymentMethod {
-  payment_method_id: string;
-}
-⋮----
-interface TransferSource {
-  type: string;
-  network: string;
-  payment_method_id: string;
-  external_payment_method: TransferExternalPaymentMethod;
-}
-⋮----
-interface TransferTarget {
-  type: string;
-  network: string;
-  payment_method_id: string;
-  ledger_account: TransferLedgerAccount;
-}
-⋮----
-interface TransferFee {
-  title: string;
-  description: string;
-  amount: TransferAmount;
-  type: string;
-}
-⋮----
-export interface CBAppTransferDepositWithdrawal {
-  user_entered_amount: TransferAmount;
-  amount: TransferAmount;
-  total: TransferAmount;
-  subtotal: TransferAmount;
-  idem: string;
-  committed: boolean;
-  id: string;
-  instant: boolean;
-  source: TransferSource;
-  target: TransferTarget;
-  payout_at: string;
-  status: string;
-  user_reference: string;
-  type: string;
-  created_at: string | null;
-  updated_at: string | null;
-  user_warnings: any[];
-  fees: any[];
-  total_fee: TransferFee;
-  cancellation_reason: string | null;
-  hold_days: number;
-  nextStep: any | null;
-  checkout_url: string;
-  requires_completion_step: boolean;
-}
-⋮----
-export interface CBAppTransfer {
-  transfer: CBAppTransferDepositWithdrawal;
-}
-/**
- *
- * Subscriptions Endpoints
- *
- */
-⋮----
-export interface CBAppCoinbaseOneSubscription {
-  status: string;
-  tier: string;
-  current_period_end: string;
-}
-⋮----
-/**
- *
- * DATA - Currencies Endpoints
- *
- */
-⋮----
-export interface CBAppFiatCurrency {
-  id: string;
-  name: string;
-  min_size: string;
-}
-⋮----
-export interface CBAppCryptocurrency {
-  code: string;
-  name: string;
-  color: string;
-  sort_index: number;
-  exponent: number;
-  type: string;
-  address_regex: string;
-  asset_id: string;
-}
-⋮----
-/**
- *
- * DATA- Exchange rates Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA - Prices Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA - Time Endpoints
- *
- */
-
-================
 File: src/types/response/coinbase-international.ts
 ================
 /**
@@ -1883,60 +1580,6 @@ File: src/types/response/coinbase-prime.ts
  * Transactions Endpoints
  *
  */
-⋮----
-/**
- *
- * Travel Rule Endpoints
- *
- */
-⋮----
-export interface PrimeTravelRuleDetailedAddress {
-  address_1?: string;
-  address_2?: string;
-  address_3?: string;
-  city?: string;
-  state?: string;
-  country_code?: string;
-  postal_code?: string;
-}
-⋮----
-export interface PrimeTravelRuleNaturalPersonName {
-  first_name?: string;
-  middle_name?: string;
-  last_name?: string;
-}
-⋮----
-export interface PrimeTravelRuleParty {
-  name?: string;
-  natural_person_name?: PrimeTravelRuleNaturalPersonName;
-  address?: PrimeTravelRuleDetailedAddress;
-  wallet_type?:
-    | 'TRAVEL_RULE_WALLET_TYPE_VASP'
-    | 'TRAVEL_RULE_WALLET_TYPE_SELF_CUSTODIED';
-  vasp_id?: string;
-  vasp_name?: string;
-  personal_id?: string;
-  date_of_birth?: {
-    year?: number;
-    month?: number;
-    day?: number;
-  };
-  telephone_number?: string;
-  account_id?: string;
-  vasp_address?: PrimeTravelRuleDetailedAddress;
-}
-⋮----
-export interface GetPrimeTransactionTravelRuleDataResponse {
-  fulfilled: boolean;
-  is_self?: boolean;
-  originator?: PrimeTravelRuleParty;
-  beneficiary?: PrimeTravelRuleParty;
-  amount?: string;
-  amount_currency?: string;
-  fiat_amount?: string;
-  fiat_amount_currency?: string;
-  blockchain_network?: string;
-}
 ⋮----
 /**
  *
@@ -2118,359 +1761,6 @@ export interface WsAPITopicRequestParamMap {
 export interface WsAPITopicResponseMap {
   [k: string]: never;
 }
-
-================
-File: src/CBAppClient.ts
-================
-import { AxiosRequestConfig } from 'axios';
-⋮----
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import {
-  getParamsFromURL,
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-} from './lib/requestUtils.js';
-import {
-  CBAppDepositFundsRequest,
-  CBAppSendMoneyRequest,
-  CBAppTransferMoneyRequest,
-  CBAppWithdrawFundsRequest,
-} from './types/request/coinbase-app-client.js';
-import {
-  CBAppAccount,
-  CBAppAddress,
-  CBAppCoinbaseOneSubscription,
-  CBAppCryptocurrency,
-  CBAppDepositWithdrawal,
-  CBAppFiatCurrency,
-  CBAppPagination,
-  CBAppTransaction,
-  CBAppTransfer,
-} from './types/response/coinbase-app-client.js';
-⋮----
-/**
- * REST client for Coinbase's Coinbase App API:
- * https://docs.cdp.coinbase.com/coinbase-app/docs/welcome
- */
-export class CBAppClient extends BaseRestClient
-⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
-⋮----
-// Some endpoints return a warning if a version header isn't included: https://docs.cdp.coinbase.com/coinbase-app/docs/versioning
-// Currently set to a date from the changelog: https://docs.cdp.coinbase.com/coinbase-app/docs/changelog
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   *
-   * Account Endpoints
-   *
-   */
-⋮----
-/**
-   * List Accounts
-   *
-   * List a current user's accounts to which the authentication method has access to.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of accounts.
-   */
-getAccounts(params?: {
-    paginationURL?: string;
-    starting_after?: string;
-}): Promise<
-⋮----
-/**
-   * Show Account
-   *
-   * Get a current user's account by account ID or currency string.
-   */
-getAccount(params:
-⋮----
-/**
-   *
-   * Address Endpoints
-   *
-   */
-⋮----
-/**
-   * Create Address
-   *
-   * Creates a new address for an account. Addresses can be created for wallet account types.
-   */
-createAddress(params:
-⋮----
-/**
-   * List Addresses
-   *
-   * Lists addresses for an account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of addresses.
-   */
-getAddresses(params: {
-    account_id: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   * Show Address
-   *
-   * Get an single address for an account.
-   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
-   *
-   * !! An address can only be associated with one account. See Create Address to create new addresses.
-   */
-getAddress(params:
-⋮----
-/**
-   * List Address Transactions
-   *
-   * List transactions that have been sent to a specific address.
-   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
-   */
-getAddressTransactions(params: {
-    account_id: string;
-    addressId: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   *
-   * Transactions Endpoints
-   *
-   */
-⋮----
-/**
-   * Send Money
-   *
-   * Send funds to a network address for any Coinbase supported asset, or email address of the recipient.
-   * No transaction fees are required for off-blockchain cryptocurrency transactions.
-   *
-   * TRAVEL RULE DATA GUIDE: https://docs.cdp.coinbase.com/coinbase-app/docs/coinbase-app-travel-rule
-   */
-sendMoney(
-    params: CBAppSendMoneyRequest,
-): Promise<
-⋮----
-/**
-   * Transfer Money
-   *
-   * Transfer any Coinbase supported digital asset between two of a single user's accounts.
-   * Accounts must support the same currency for transfers to be successful.
-   */
-transferMoney(
-    params: CBAppTransferMoneyRequest,
-): Promise<
-⋮----
-/**
-   * List Transactions
-   *
-   * Lists the transactions of an account by account ID.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
-   */
-getTransactions(params: {
-    account_id: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   * Show Transaction
-   *
-   * Get a single transaction for an account.
-   */
-getTransaction(params: {
-    account_id: string;
-    transactionId: string;
-}): Promise<
-⋮----
-/**
-   *
-   * Deposits Endpoints
-   *
-   */
-⋮----
-/**
-   * Deposit Funds
-   *
-   * Deposits user-defined amount of funds to a fiat account.
-   */
-depositFunds(params: CBAppDepositFundsRequest): Promise<CBAppTransfer>
-⋮----
-/**
-   * Commit Deposit
-   *
-   * Completes a deposit that is created in commit: false state.
-   */
-commitDeposit(params: {
-    account_id: string;
-    deposit_id: string;
-}): Promise<CBAppTransfer>
-⋮----
-/**
-   * List Deposits
-   *
-   * Lists fiat deposits for an account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of deposits.
-   */
-getDeposits(params:
-⋮----
-/**
-   * Show Deposit
-   *
-   * Get one deposit by deposit Id.
-   */
-getDeposit(params:
-⋮----
-/**
-   *
-   * Withdrawals Endpoints
-   *
-   */
-⋮----
-/**
-   * Withdraw Funds
-   *
-   * Withdraws a user-defined amount of funds from a fiat account.
-   */
-withdrawFunds(params: CBAppWithdrawFundsRequest): Promise<CBAppTransfer>
-⋮----
-/**
-   * Commit Withdrawal
-   *
-   * Completes a withdrawal that is created in commit: false state.
-   */
-commitWithdrawal(params: {
-    account_id: string;
-    withdrawal_id: string;
-}): Promise<CBAppTransfer>
-⋮----
-/**
-   * List Withdrawals
-   *
-   * Lists withdrawals for an account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of withdrawals.
-   */
-getWithdrawals(params: {
-    account_id: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   * Show Withdrawal
-   *
-   * Get a single withdrawal.
-   */
-getWithdrawal(params: {
-    account_id: string;
-    withdrawal_id: string;
-}): Promise<
-⋮----
-/**
-   *
-   * Subscriptions Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Coinbase One Subscription
-   *
-   * Returns a user's Coinbase One subscription status, tier, and current period end.
-   * Requires OAuth2 scope: wallet:subscription:read
-   */
-getCoinbaseOneSubscription(): Promise<
-⋮----
-/**
-   *
-   * DATA - Currencies Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Fiat Currencies
-   *
-   * Lists known fiat currencies. Currency codes conform to the ISO 4217 standard where possible.
-   * Currencies with no representation in ISO 4217 may use a custom code.
-   */
-getFiatCurrencies(): Promise<
-⋮----
-/**
-   * Get Cryptocurrencies
-   *
-   * Lists known cryptocurrencies.
-   */
-getCryptocurrencies(): Promise<CBAppCryptocurrency[]>
-⋮----
-/**
-   *
-   * DATA- Exchange rates Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Exchange Rates
-   *
-   * Get current exchange rates. Default base currency is USD but it can be defined as any supported currency.
-   * Returned rates will define the exchange rate for one unit of the base currency.
-   */
-getExchangeRates(params?:
-⋮----
-/**
-   *
-   * DATA - Prices Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Buy Price
-   *
-   * Get the total price to buy one bitcoin or ether.
-   * This endpoint doesn't require authentication.
-   */
-getBuyPrice(params:
-⋮----
-/**
-   * Get Sell Price
-   *
-   * Get the total price to sell one bitcoin or ether.
-   * This endpoint doesn't require authentication.
-   */
-getSellPrice(params:
-⋮----
-/**
-   * Get Spot Price
-   *
-   * Get the current market price for bitcoin. This is usually somewhere in between the buy and sell price.
-   * This endpoint doesn't require authentication.
-   */
-getSpotPrice(params:
-⋮----
-/**
-   *
-   * DATA - Time Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Current Time
-   *
-   * Get the API server time.
-   * This endpoint doesn't require authentication.
-   */
-getCurrentTime(): Promise<
 
 ================
 File: src/CBCommerceClient.ts
@@ -5221,526 +4511,6 @@ export interface INTXWithdrawToCounterpartyIdRequest {
  */
 
 ================
-File: src/types/request/coinbase-prime.ts
-================
-/**
- *
- * Allocation Endpoints
- *
- */
-⋮----
-export interface CreatePrimePortfolioAllocationsRequest {
-  allocation_id?: string;
-  source_portfolio_id?: string;
-  product_id?: string;
-  order_ids?: string[];
-  allocation_legs: {
-    allocation_leg_id: string;
-    destination_portfolio_id: string;
-    amount: string;
-  }[];
-  size_type?: 'BASE' | 'QUOTE' | 'PERCENT';
-  remainder_destination_portfolio?: string;
-}
-⋮----
-export interface CreatePrimePortfolioNetAllocationsRequest {
-  netting_id?: string;
-  source_portfolio_id?: string;
-  product_id?: string;
-  order_ids?: string[];
-  allocation_legs: {
-    allocation_leg_id: string;
-    destination_portfolio_id: string;
-    amount: string;
-  }[];
-  size_type?: 'BASE' | 'QUOTE' | 'PERCENT';
-  remainder_destination_portfolio?: string;
-}
-⋮----
-export interface GetPrimePortfolioAllocationsRequest {
-  portfolio_id: string;
-  product_ids?: string[];
-  order_side?: 'BUY' | 'SELL';
-  start_date?: string;
-  end_date?: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-}
-/**
- *
- * Invoice Endpoints
- *
- */
-⋮----
-export interface GetPrimeInvoicesRequest {
-  entity_id: string;
-  states?: string[];
-  billing_year?: number;
-  billing_month?: number;
-  cursor?: number;
-  limit?: number;
-}
-/**
- *
- * Assets Endpoints
- *
- */
-⋮----
-/**
- *
- * Payment Methods Endpoints
- *
- */
-⋮----
-/**
- *
- * Users Endpoints
- *
- */
-⋮----
-export interface GetPrimeUsersRequest {
-  entity_id: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'ASC' | 'DESC';
-}
-⋮----
-export interface GetPrimePortfolioUsersRequest {
-  portfolio_id: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: string;
-}
-/**
- *
- * Portfolios Endpoints
- *
- */
-⋮----
-/**
- *
- * Activities Endpoints
- *
- */
-⋮----
-export interface GetPrimeActivitiesRequest {
-  portfolio_id: string;
-  symbols?: string[];
-  categories?: string[];
-  statuses?: string[];
-  start_time?: string;
-  end_time?: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'ASC' | 'DESC';
-}
-⋮----
-export interface GetPrimeEntityActivitiesRequest {
-  entity_id: string;
-  activity_level?: 'ACTIVITY_LEVEL_ALL';
-  symbols?: string[];
-  categories?: string[];
-  statuses?: string[];
-  start_time?: string;
-  end_time?: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'ASC' | 'DESC';
-}
-⋮----
-export interface GetPrimePortfolioActivityByIdRequest {
-  portfolio_id: string;
-  activity_id: string;
-}
-/**
- *
- * Address Book Endpoints
- *
- */
-⋮----
-export interface GetPrimeAddressBookRequest {
-  portfolio_id: string;
-  currency_symbol?: string;
-  search?: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-}
-⋮----
-export interface CreatePrimeAddressBookEntryRequest {
-  portfolio_id: string;
-  address: string;
-  currency_symbol: string;
-  name: string;
-  account_identifier?: string;
-}
-/**
- *
- * Balances Endpoints
- *
- */
-⋮----
-export interface GetPrimeWeb3WalletBalancesRequest {
-  portfolio_id: string;
-  wallet_id: string;
-  visibility_statuses?: string[];
-  cursor?: string;
-  limit?: number;
-}
-⋮----
-/**
- *
- * Commission Endpoints
- *
- */
-⋮----
-/**
- *
- * Orders Endpoints
- *
- */
-⋮----
-export interface GetPrimePortfolioFillsRequest {
-  portfolio_id: string;
-  start_date: string;
-  end_date?: string;
-  limit?: number;
-  cursor?: string;
-  sort_direction?: 'DESC' | 'ASC';
-}
-⋮----
-export interface GetPrimeOpenOrdersRequest {
-  portfolio_id: string;
-  product_ids?: string[];
-  order_type?:
-    | 'MARKET'
-    | 'LIMIT'
-    | 'TWAP'
-    | 'BLOCK'
-    | 'VWAP'
-    | 'STOP_LIMIT'
-    | 'PEG';
-  sort_direction?: 'DESC' | 'ASC';
-  start_date: string;
-  order_side?: 'BUY' | 'SELL';
-  end_date?: string;
-}
-⋮----
-export interface SubmitPrimeOrderRequest {
-  portfolio_id: string;
-  product_id: string;
-  side: 'BUY' | 'SELL';
-  client_order_id?: string;
-  type?: 'MARKET' | 'LIMIT' | 'TWAP' | 'VWAP' | 'STOP_LIMIT' | 'PEG';
-  base_quantity?: string;
-  quote_value?: string;
-  limit_price?: string;
-  stop_price?: string;
-  start_time?: string;
-  expiry_time?: string;
-  time_in_force?:
-    | 'FILL_OR_KILL'
-    | 'GOOD_UNTIL_DATE_TIME'
-    | 'GOOD_UNTIL_CANCELLED'
-    | 'IMMEDIATE_OR_CANCEL';
-  stp_id?: string;
-  display_quote_size?: string;
-  display_base_size?: string;
-  is_raise_exact?: boolean;
-  historical_pov?: string;
-  peg_offset_type?:
-    | 'PEG_OFFSET_TYPE_PRICE'
-    | 'PEG_OFFSET_TYPE_BPS'
-    | 'PEG_OFFSET_TYPE_BASIS_POINTS'
-    | 'PEG_OFFSET_TYPE_DEPTH'
-    | 'PEG_OFFSET_TYPE_CUMULATIVE_DEPTH_IN_BASE_UNITS';
-  offset?: string;
-  wig_level?: string;
-}
-⋮----
-export interface EditPrimeOrderRequest {
-  portfolio_id: string;
-  order_id: string;
-  orig_client_order_id: string;
-  client_order_id: string;
-  product_id?: string;
-  base_quantity?: string;
-  quote_value?: string;
-  limit_price?: string;
-  expiry_time?: string;
-  display_quote_size?: string;
-  display_base_size?: string;
-  stop_price?: string;
-  offset?: string;
-  wig_level?: string;
-}
-⋮----
-export interface RotatePrimeApiKeyRequest {
-  api_key_id?: string;
-}
-⋮----
-export interface GetPrimeOrderPreviewRequest {
-  portfolio_id: string;
-  product_id: string;
-  side: 'BUY' | 'SELL';
-  type?: 'MARKET' | 'LIMIT' | 'TWAP' | 'BLOCK' | 'VWAP' | 'STOP_LIMIT' | 'PEG';
-  base_quantity?: string;
-  quote_value?: string;
-  limit_price?: string;
-  stop_price?: string;
-  start_time?: string;
-  expiry_time?: string;
-  time_in_force?:
-    | 'FILL_OR_KILL'
-    | 'GOOD_UNTIL_DATE_TIME'
-    | 'GOOD_UNTIL_CANCELLED'
-    | 'IMMEDIATE_OR_CANCEL';
-  is_raise_exact?: boolean;
-  historical_pov?: string;
-  peg_offset_type?:
-    | 'PEG_OFFSET_TYPE_PRICE'
-    | 'PEG_OFFSET_TYPE_BPS'
-    | 'PEG_OFFSET_TYPE_BASIS_POINTS'
-    | 'PEG_OFFSET_TYPE_DEPTH'
-    | 'PEG_OFFSET_TYPE_CUMULATIVE_DEPTH_IN_BASE_UNITS';
-  offset?: string;
-  wig_level?: string;
-}
-⋮----
-export interface GetPrimePortfolioOrdersRequest {
-  portfolio_id: string;
-  order_statuses?: (
-    | 'FILLED'
-    | 'CANCELLED'
-    | 'EXPIRED'
-    | 'FAILED'
-    | 'PENDING'
-  )[];
-  product_ids?: string[];
-  order_type?:
-    | 'MARKET'
-    | 'LIMIT'
-    | 'TWAP'
-    | 'BLOCK'
-    | 'VWAP'
-    | 'STOP_LIMIT'
-    | 'PEG';
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-  order_side?: 'BUY' | 'SELL';
-  start_date?: string;
-  end_date?: string;
-}
-⋮----
-export interface GetPrimeOrderFillsRequest {
-  portfolio_id: string;
-  order_id: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-}
-/**
- *
- * Products Endpoints
- *
- */
-⋮----
-export interface GetPrimePortfolioProductsRequest {
-  portfolio_id: string;
-  cursor?: string;
-  /** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-  /** If unset, returns all product types available for the portfolio (including FUTURE). */
-  product_type?: 'SPOT' | 'FUTURE' | 'OPTION';
-  /** Only applicable when product_type = FUTURE. */
-  contract_expiry_type?:
-    | 'CONTRACT_EXPIRY_TYPE_EXPIRING'
-    | 'CONTRACT_EXPIRY_TYPE_PERPETUAL';
-  /** Filter by expiry status for expiring futures. */
-  expiring_contract_status?:
-    | 'EXPIRING_CONTRACT_STATUS_UNEXPIRED'
-    | 'EXPIRING_CONTRACT_STATUS_EXPIRED'
-    | 'EXPIRING_CONTRACT_STATUS_ALL';
-}
-⋮----
-/** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
-⋮----
-/** If unset, returns all product types available for the portfolio (including FUTURE). */
-⋮----
-/** Only applicable when product_type = FUTURE. */
-⋮----
-/** Filter by expiry status for expiring futures. */
-⋮----
-/**
- *
- * Travel Rule Endpoints
- *
- */
-⋮----
-export interface GetPrimeTransactionTravelRuleDataRequest {
-  portfolio_id: string;
-  transaction_id: string;
-}
-⋮----
-/**
- *
- * Transactions Endpoints
- *
- */
-⋮----
-export interface GetPrimePortfolioTransactionsRequest {
-  portfolio_id: string;
-  symbols?: string[];
-  types?: string[];
-  start_time?: string;
-  end_time?: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-}
-⋮----
-export interface CreatePrimeConversionRequest {
-  portfolio_id: string;
-  wallet_id: string;
-  amount: string;
-  destination: string;
-  idempotency_key: string;
-  source_symbol: string;
-  destination_symbol: string;
-}
-⋮----
-export interface GetPrimeWalletTransactionsRequest {
-  portfolio_id: string;
-  wallet_id: string;
-  types?: string[];
-  start_time?: string;
-  end_time?: string;
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-}
-⋮----
-export interface CreatePrimeTransferRequest {
-  portfolio_id: string;
-  wallet_id: string;
-  amount: string;
-  destination: string;
-  idempotency_key: string;
-  currency_symbol: string;
-}
-⋮----
-export interface CreatePrimeWithdrawalRequest {
-  portfolio_id: string;
-  wallet_id: string;
-  amount: string;
-  destination_type: 'DESTINATION_PAYMENT_METHOD' | 'DESTINATION_BLOCKCHAIN';
-  idempotency_key: string;
-  currency_symbol: string;
-  payment_method?: {
-    payment_method_id: string;
-  };
-  blockchain_address?: {
-    address: string;
-    account_identifier?: string;
-  };
-}
-/**
- *
- * Wallets Endpoints
- *
- */
-⋮----
-export interface GetPrimePortfolioWalletsRequest {
-  portfolio_id: string;
-  type: 'VAULT' | 'TRADING' | 'WALLET_TYPE_OTHER' | 'WEB3';
-  cursor?: string;
-  limit?: number;
-  sort_direction?: 'DESC' | 'ASC';
-  symbols?: string[];
-}
-⋮----
-export interface CreatePrimeWalletRequest {
-  portfolio_id: string;
-  name: string;
-  symbol: string;
-  wallet_type: 'VAULT' | 'TRADING' | 'WALLET_TYPE_OTHER' | 'WEB3';
-}
-⋮----
-export interface GetPrimeWalletDepositInstructionsRequest {
-  portfolio_id: string;
-  wallet_id: string;
-  deposit_type?:
-    | 'UNKNOWN_WALLET_DEPOSIT_TYPE'
-    | 'CRYPTO'
-    | 'WIRE'
-    | 'SEN'
-    | 'SWIFT';
-}
-⋮----
-/**
- *
- * Financing Endpoints
- *
- */
-⋮----
-export interface GetPrimeEntityAccrualsRequest {
-  entity_id: string;
-  portfolio_id?: string;
-  start_date?: string;
-  end_date?: string;
-}
-⋮----
-export interface GetPrimeEntityLocateAvailabilitiesRequest {
-  entity_id: string;
-  conversion_date?: string;
-  locate_date?: string;
-}
-⋮----
-export interface GetPrimeEntityMarginSummariesRequest {
-  entity_id: string;
-  start_date?: string;
-  end_date?: string;
-}
-⋮----
-export interface GetPrimeEntityTFTieredFeesRequest {
-  entity_id: string;
-  effective_at?: string;
-}
-⋮----
-export interface GetPrimePortfolioAccrualsRequest {
-  portfolio_id: string;
-  start_date?: string;
-  end_date?: string;
-}
-⋮----
-export interface GetPrimePortfolioBuyingPowerRequest {
-  portfolio_id: string;
-  base_currency: string;
-  quote_currency: string;
-}
-⋮----
-export interface GetPrimePortfolioLocatesRequest {
-  portfolio_id: string;
-  locate_ids?: string[];
-  conversion_date?: string;
-  locate_date?: string;
-}
-⋮----
-export interface GetPrimePortfolioMarginConversionsRequest {
-  portfolio_id: string;
-  start_date?: string;
-  end_date?: string;
-}
-⋮----
-export interface GetPrimePortfolioWithdrawalPowerRequest {
-  portfolio_id: string;
-  symbol: string;
-}
-
-================
 File: src/types/response/advanced-trade-client.ts
 ================
 /**
@@ -6596,6 +5366,309 @@ export interface AdvTradeApiKeyPermissions {
   portfolio_uuid: string;
   portfolio_type: string;
 }
+
+================
+File: src/types/response/coinbase-app-client.ts
+================
+export interface CBAppPagination {
+  ending_before?: string | null;
+  starting_after?: string | null;
+  limit?: number;
+  order?: string;
+  previous_uri: string | null;
+  next_uri: string | null;
+}
+⋮----
+/**
+ *
+ * Account Endpoints
+ *
+ */
+⋮----
+interface AccountCurrency {
+  address_regex: string;
+  asset_id: string;
+  code: string;
+  color: string;
+  exponent: number;
+  name: string;
+  slug: string;
+  sort_index: number;
+  type: string;
+}
+⋮----
+interface AccountBalance {
+  amount: string;
+  currency: string;
+}
+⋮----
+export interface CBAppAccount {
+  id: string;
+  name: string;
+  primary: boolean;
+  type: string;
+  currency: AccountCurrency;
+  balance: AccountBalance;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+  ready: boolean;
+}
+⋮----
+/**
+ *
+ * Address Endpoints
+ *
+ */
+⋮----
+export interface CBAppAddress {
+  id: string;
+  address: string;
+  name?: string;
+  network: string;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+}
+⋮----
+/**
+ *
+ * Transactions Endpoints
+ *
+ */
+⋮----
+interface TransactionAmount {
+  amount: string;
+  currency: string;
+}
+⋮----
+interface TransactionNetwork {
+  status: string;
+  name: string;
+  hash?: string;
+  transaction_fee?: TransactionAmount;
+  transaction_amount?: TransactionAmount;
+  network_name?: string;
+  status_description?: string | null;
+}
+⋮----
+interface TransactionFrom {
+  id: string;
+  resource: string;
+  resource_path?: string;
+}
+⋮----
+interface TransactionTo {
+  resource: string;
+  address?: string;
+  email?: string;
+  id?: string;
+  resource_path?: string;
+}
+⋮----
+interface TransactionDetails {
+  title: string;
+  subtitle: string;
+  header?: string;
+  health?: string;
+  subsidebar_label?: string | null;
+}
+⋮----
+interface AdvancedTradeFill {
+  fill_price: string;
+  product_id: string;
+  order_id: string;
+  commission: string;
+  order_side: 'BUY' | 'SELL';
+}
+⋮----
+export interface CBAppTransaction {
+  id: string;
+  type: string;
+  status: string;
+  amount: TransactionAmount;
+  native_amount: TransactionAmount;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+  network?: TransactionNetwork;
+  from?: TransactionFrom;
+  to?: TransactionTo;
+  details?: TransactionDetails;
+  instant_exchange?: boolean;
+  advanced_trade_fill?: AdvancedTradeFill;
+  cancelable?: boolean;
+  idem?: string;
+}
+⋮----
+/**
+ *
+ * Deposits/Withdrawal Endpoints
+ *
+ */
+⋮----
+interface DepositWithdrawalPaymentMethod {
+  id: string;
+  resource: string;
+  resource_path: string;
+}
+⋮----
+interface DepositWithdrawalTransaction {
+  id: string;
+  resource: string;
+  resource_path: string;
+}
+⋮----
+interface DepositWithdrawalAmountCurrency {
+  amount: string;
+  currency: string;
+}
+⋮----
+export interface CBAppDepositWithdrawal {
+  id: string;
+  status: string;
+  payment_method: DepositWithdrawalPaymentMethod;
+  transaction: DepositWithdrawalTransaction;
+  amount: DepositWithdrawalAmountCurrency;
+  subtotal: DepositWithdrawalAmountCurrency;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+  committed: boolean;
+  fee: DepositWithdrawalAmountCurrency;
+  payout_at: string;
+}
+⋮----
+interface TransferAmount {
+  value: string;
+  currency: string;
+}
+⋮----
+interface TransferOwner {
+  id: string;
+  uuid: string;
+  user_uuid: string;
+  type: string;
+}
+⋮----
+interface TransferLedgerAccount {
+  account_id: string;
+  currency: string;
+  owner: TransferOwner;
+}
+⋮----
+interface TransferExternalPaymentMethod {
+  payment_method_id: string;
+}
+⋮----
+interface TransferSource {
+  type: string;
+  network: string;
+  payment_method_id: string;
+  external_payment_method: TransferExternalPaymentMethod;
+}
+⋮----
+interface TransferTarget {
+  type: string;
+  network: string;
+  payment_method_id: string;
+  ledger_account: TransferLedgerAccount;
+}
+⋮----
+interface TransferFee {
+  title: string;
+  description: string;
+  amount: TransferAmount;
+  type: string;
+}
+⋮----
+export interface CBAppTransferDepositWithdrawal {
+  user_entered_amount: TransferAmount;
+  amount: TransferAmount;
+  total: TransferAmount;
+  subtotal: TransferAmount;
+  idem: string;
+  committed: boolean;
+  id: string;
+  instant: boolean;
+  source: TransferSource;
+  target: TransferTarget;
+  payout_at: string;
+  status: string;
+  user_reference: string;
+  type: string;
+  created_at: string | null;
+  updated_at: string | null;
+  user_warnings: any[];
+  fees: any[];
+  total_fee: TransferFee;
+  cancellation_reason: string | null;
+  hold_days: number;
+  nextStep: any | null;
+  checkout_url: string;
+  requires_completion_step: boolean;
+}
+⋮----
+export interface CBAppTransfer {
+  transfer: CBAppTransferDepositWithdrawal;
+}
+/**
+ *
+ * Subscriptions Endpoints
+ *
+ */
+⋮----
+export interface CBAppCoinbaseOneSubscription {
+  status: string;
+  tier: string;
+  current_period_end: string;
+}
+⋮----
+/**
+ *
+ * DATA - Currencies Endpoints
+ *
+ */
+⋮----
+export interface CBAppFiatCurrency {
+  id: string;
+  name: string;
+  min_size: string;
+}
+⋮----
+export interface CBAppCryptocurrency {
+  code: string;
+  name: string;
+  color: string;
+  sort_index: number;
+  exponent: number;
+  type: string;
+  address_regex: string;
+  asset_id: string;
+}
+⋮----
+/**
+ *
+ * DATA- Exchange rates Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA - Prices Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA - Time Endpoints
+ *
+ */
 
 ================
 File: src/types/response/coinbase-exchange.ts
@@ -7477,6 +6550,359 @@ getPaymentMethod(params:
 getApiKeyPermissions(): Promise<AdvTradeApiKeyPermissions>
 
 ================
+File: src/CBAppClient.ts
+================
+import { AxiosRequestConfig } from 'axios';
+⋮----
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import {
+  getParamsFromURL,
+  REST_CLIENT_TYPE_ENUM,
+  RestClientOptions,
+  RestClientType,
+} from './lib/requestUtils.js';
+import {
+  CBAppDepositFundsRequest,
+  CBAppSendMoneyRequest,
+  CBAppTransferMoneyRequest,
+  CBAppWithdrawFundsRequest,
+} from './types/request/coinbase-app-client.js';
+import {
+  CBAppAccount,
+  CBAppAddress,
+  CBAppCoinbaseOneSubscription,
+  CBAppCryptocurrency,
+  CBAppDepositWithdrawal,
+  CBAppFiatCurrency,
+  CBAppPagination,
+  CBAppTransaction,
+  CBAppTransfer,
+} from './types/response/coinbase-app-client.js';
+⋮----
+/**
+ * REST client for Coinbase's Coinbase App API:
+ * https://docs.cdp.coinbase.com/coinbase-app/docs/welcome
+ */
+export class CBAppClient extends BaseRestClient
+⋮----
+constructor(
+    restClientOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {},
+)
+⋮----
+// Some endpoints return a warning if a version header isn't included: https://docs.cdp.coinbase.com/coinbase-app/docs/versioning
+// Currently set to a date from the changelog: https://docs.cdp.coinbase.com/coinbase-app/docs/changelog
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * Account Endpoints
+   *
+   */
+⋮----
+/**
+   * List Accounts
+   *
+   * List a current user's accounts to which the authentication method has access to.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of accounts.
+   */
+getAccounts(params?: {
+    paginationURL?: string;
+    starting_after?: string;
+}): Promise<
+⋮----
+/**
+   * Show Account
+   *
+   * Get a current user's account by account ID or currency string.
+   */
+getAccount(params:
+⋮----
+/**
+   *
+   * Address Endpoints
+   *
+   */
+⋮----
+/**
+   * Create Address
+   *
+   * Creates a new address for an account. Addresses can be created for wallet account types.
+   */
+createAddress(params:
+⋮----
+/**
+   * List Addresses
+   *
+   * Lists addresses for an account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of addresses.
+   */
+getAddresses(params: {
+    account_id: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   * Show Address
+   *
+   * Get an single address for an account.
+   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
+   *
+   * !! An address can only be associated with one account. See Create Address to create new addresses.
+   */
+getAddress(params:
+⋮----
+/**
+   * List Address Transactions
+   *
+   * List transactions that have been sent to a specific address.
+   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
+   */
+getAddressTransactions(params: {
+    account_id: string;
+    addressId: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Transactions Endpoints
+   *
+   */
+⋮----
+/**
+   * Send Money
+   *
+   * Send funds to a network address for any Coinbase supported asset, or email address of the recipient.
+   * No transaction fees are required for off-blockchain cryptocurrency transactions.
+   *
+   * TRAVEL RULE DATA GUIDE: https://docs.cdp.coinbase.com/coinbase-app/docs/coinbase-app-travel-rule
+   */
+sendMoney(
+    params: CBAppSendMoneyRequest,
+): Promise<
+⋮----
+/**
+   * Transfer Money
+   *
+   * Transfer any Coinbase supported digital asset between two of a single user's accounts.
+   * Accounts must support the same currency for transfers to be successful.
+   */
+transferMoney(
+    params: CBAppTransferMoneyRequest,
+): Promise<
+⋮----
+/**
+   * List Transactions
+   *
+   * Lists the transactions of an account by account ID.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
+   */
+getTransactions(params: {
+    account_id: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   * Show Transaction
+   *
+   * Get a single transaction for an account.
+   */
+getTransaction(params: {
+    account_id: string;
+    transactionId: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Deposits Endpoints
+   *
+   */
+⋮----
+/**
+   * Deposit Funds
+   *
+   * Deposits user-defined amount of funds to a fiat account.
+   */
+depositFunds(params: CBAppDepositFundsRequest): Promise<CBAppTransfer>
+⋮----
+/**
+   * Commit Deposit
+   *
+   * Completes a deposit that is created in commit: false state.
+   */
+commitDeposit(params: {
+    account_id: string;
+    deposit_id: string;
+}): Promise<CBAppTransfer>
+⋮----
+/**
+   * List Deposits
+   *
+   * Lists fiat deposits for an account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of deposits.
+   */
+getDeposits(params:
+⋮----
+/**
+   * Show Deposit
+   *
+   * Get one deposit by deposit Id.
+   */
+getDeposit(params:
+⋮----
+/**
+   *
+   * Withdrawals Endpoints
+   *
+   */
+⋮----
+/**
+   * Withdraw Funds
+   *
+   * Withdraws a user-defined amount of funds from a fiat account.
+   */
+withdrawFunds(params: CBAppWithdrawFundsRequest): Promise<CBAppTransfer>
+⋮----
+/**
+   * Commit Withdrawal
+   *
+   * Completes a withdrawal that is created in commit: false state.
+   */
+commitWithdrawal(params: {
+    account_id: string;
+    withdrawal_id: string;
+}): Promise<CBAppTransfer>
+⋮----
+/**
+   * List Withdrawals
+   *
+   * Lists withdrawals for an account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of withdrawals.
+   */
+getWithdrawals(params: {
+    account_id: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   * Show Withdrawal
+   *
+   * Get a single withdrawal.
+   */
+getWithdrawal(params: {
+    account_id: string;
+    withdrawal_id: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Subscriptions Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Coinbase One Subscription
+   *
+   * Returns a user's Coinbase One subscription status, tier, and current period end.
+   * Requires OAuth2 scope: wallet:subscription:read
+   */
+getCoinbaseOneSubscription(): Promise<
+⋮----
+/**
+   *
+   * DATA - Currencies Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Fiat Currencies
+   *
+   * Lists known fiat currencies. Currency codes conform to the ISO 4217 standard where possible.
+   * Currencies with no representation in ISO 4217 may use a custom code.
+   */
+getFiatCurrencies(): Promise<
+⋮----
+/**
+   * Get Cryptocurrencies
+   *
+   * Lists known cryptocurrencies.
+   */
+getCryptocurrencies(): Promise<CBAppCryptocurrency[]>
+⋮----
+/**
+   *
+   * DATA- Exchange rates Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Exchange Rates
+   *
+   * Get current exchange rates. Default base currency is USD but it can be defined as any supported currency.
+   * Returned rates will define the exchange rate for one unit of the base currency.
+   */
+getExchangeRates(params?:
+⋮----
+/**
+   *
+   * DATA - Prices Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Buy Price
+   *
+   * Get the total price to buy one bitcoin or ether.
+   * This endpoint doesn't require authentication.
+   */
+getBuyPrice(params:
+⋮----
+/**
+   * Get Sell Price
+   *
+   * Get the total price to sell one bitcoin or ether.
+   * This endpoint doesn't require authentication.
+   */
+getSellPrice(params:
+⋮----
+/**
+   * Get Spot Price
+   *
+   * Get the current market price for bitcoin. This is usually somewhere in between the buy and sell price.
+   * This endpoint doesn't require authentication.
+   */
+getSpotPrice(params:
+⋮----
+/**
+   *
+   * DATA - Time Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Current Time
+   *
+   * Get the API server time.
+   * This endpoint doesn't require authentication.
+   */
+getCurrentTime(): Promise<
+
+================
 File: src/CBExchangeClient.ts
 ================
 import { AxiosRequestConfig } from 'axios';
@@ -8245,6 +7671,573 @@ getWrappedAssetConversionRate(params: {
 }): Promise<any>
 
 ================
+File: LICENSE.md
+================
+Copyright 2025 Tiago Siebler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================
+File: tsconfig.json
+================
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "baseUrl": ".",
+    "noEmitOnError": true,
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": false,
+    "inlineSourceMap": false,
+    "lib": ["esnext"],
+    "listEmittedFiles": false,
+    "listFiles": false,
+    "moduleResolution": "node",
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitAny": true,
+    "noUnusedParameters": true,
+    "pretty": true,
+    "removeComments": false,
+    "resolveJsonModule": true,
+    "skipLibCheck": false,
+    "sourceMap": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "types": ["node", "jest"],
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext"
+  },
+  "compileOnSave": true,
+  "exclude": ["node_modules", "dist"],
+  "include": ["src/**/*.*", "test/**/*.*", ".eslintrc.cjs"]
+}
+
+================
+File: src/types/request/coinbase-prime.ts
+================
+/**
+ *
+ * Allocation Endpoints
+ *
+ */
+⋮----
+export interface CreatePrimePortfolioAllocationsRequest {
+  allocation_id?: string;
+  source_portfolio_id?: string;
+  product_id?: string;
+  order_ids?: string[];
+  allocation_legs: {
+    allocation_leg_id: string;
+    destination_portfolio_id: string;
+    amount: string;
+  }[];
+  size_type?: 'BASE' | 'QUOTE' | 'PERCENT';
+  remainder_destination_portfolio?: string;
+}
+⋮----
+export interface CreatePrimePortfolioNetAllocationsRequest {
+  netting_id?: string;
+  source_portfolio_id?: string;
+  product_id?: string;
+  order_ids?: string[];
+  allocation_legs: {
+    allocation_leg_id: string;
+    destination_portfolio_id: string;
+    amount: string;
+  }[];
+  size_type?: 'BASE' | 'QUOTE' | 'PERCENT';
+  remainder_destination_portfolio?: string;
+}
+⋮----
+export interface GetPrimePortfolioAllocationsRequest {
+  portfolio_id: string;
+  product_ids?: string[];
+  order_side?: 'BUY' | 'SELL';
+  start_date?: string;
+  end_date?: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+}
+/**
+ *
+ * Invoice Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeInvoicesRequest {
+  entity_id: string;
+  states?: string[];
+  billing_year?: number;
+  billing_month?: number;
+  cursor?: number;
+  limit?: number;
+}
+/**
+ *
+ * Assets Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Payment Methods Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Users Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeUsersRequest {
+  entity_id: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'ASC' | 'DESC';
+}
+⋮----
+export interface GetPrimePortfolioUsersRequest {
+  portfolio_id: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: string;
+}
+/**
+ *
+ * Portfolios Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Activities Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeActivitiesRequest {
+  portfolio_id: string;
+  symbols?: string[];
+  categories?: string[];
+  statuses?: string[];
+  start_time?: string;
+  end_time?: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'ASC' | 'DESC';
+}
+⋮----
+export interface GetPrimeEntityActivitiesRequest {
+  entity_id: string;
+  activity_level?: 'ACTIVITY_LEVEL_ALL';
+  symbols?: string[];
+  categories?: string[];
+  statuses?: string[];
+  start_time?: string;
+  end_time?: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'ASC' | 'DESC';
+}
+⋮----
+export interface GetPrimePortfolioActivityByIdRequest {
+  portfolio_id: string;
+  activity_id: string;
+}
+/**
+ *
+ * Address Book Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeAddressBookRequest {
+  portfolio_id: string;
+  currency_symbol?: string;
+  search?: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+}
+⋮----
+export interface CreatePrimeAddressBookEntryRequest {
+  portfolio_id: string;
+  address: string;
+  currency_symbol: string;
+  name: string;
+  account_identifier?: string;
+}
+/**
+ *
+ * Balances Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeWeb3WalletBalancesRequest {
+  portfolio_id: string;
+  wallet_id: string;
+  visibility_statuses?: string[];
+  cursor?: string;
+  limit?: number;
+}
+⋮----
+/**
+ *
+ * Commission Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Orders Endpoints
+ *
+ */
+⋮----
+export interface GetPrimePortfolioFillsRequest {
+  portfolio_id: string;
+  start_date: string;
+  end_date?: string;
+  limit?: number;
+  cursor?: string;
+  sort_direction?: 'DESC' | 'ASC';
+}
+⋮----
+export interface GetPrimeOpenOrdersRequest {
+  portfolio_id: string;
+  product_ids?: string[];
+  order_type?:
+    | 'MARKET'
+    | 'LIMIT'
+    | 'TWAP'
+    | 'BLOCK'
+    | 'VWAP'
+    | 'STOP_LIMIT'
+    | 'PEG';
+  sort_direction?: 'DESC' | 'ASC';
+  start_date: string;
+  order_side?: 'BUY' | 'SELL';
+  end_date?: string;
+}
+⋮----
+export interface SubmitPrimeOrderRequest {
+  portfolio_id: string;
+  product_id: string;
+  side: 'BUY' | 'SELL';
+  client_order_id?: string;
+  type?: 'MARKET' | 'LIMIT' | 'TWAP' | 'VWAP' | 'STOP_LIMIT' | 'PEG';
+  base_quantity?: string;
+  quote_value?: string;
+  limit_price?: string;
+  stop_price?: string;
+  start_time?: string;
+  expiry_time?: string;
+  time_in_force?:
+    | 'FILL_OR_KILL'
+    | 'GOOD_UNTIL_DATE_TIME'
+    | 'GOOD_UNTIL_CANCELLED'
+    | 'IMMEDIATE_OR_CANCEL';
+  stp_id?: string;
+  display_quote_size?: string;
+  display_base_size?: string;
+  is_raise_exact?: boolean;
+  historical_pov?: string;
+  peg_offset_type?:
+    | 'PEG_OFFSET_TYPE_PRICE'
+    | 'PEG_OFFSET_TYPE_BPS'
+    | 'PEG_OFFSET_TYPE_BASIS_POINTS'
+    | 'PEG_OFFSET_TYPE_DEPTH'
+    | 'PEG_OFFSET_TYPE_CUMULATIVE_DEPTH_IN_BASE_UNITS';
+  offset?: string;
+  wig_level?: string;
+}
+⋮----
+export interface EditPrimeOrderRequest {
+  portfolio_id: string;
+  order_id: string;
+  orig_client_order_id: string;
+  client_order_id: string;
+  product_id?: string;
+  base_quantity?: string;
+  quote_value?: string;
+  limit_price?: string;
+  expiry_time?: string;
+  display_quote_size?: string;
+  display_base_size?: string;
+  stop_price?: string;
+  offset?: string;
+  wig_level?: string;
+}
+⋮----
+export interface RotatePrimeApiKeyRequest {
+  api_key_id?: string;
+}
+⋮----
+export interface GetPrimeOrderPreviewRequest {
+  portfolio_id: string;
+  product_id: string;
+  side: 'BUY' | 'SELL';
+  type?: 'MARKET' | 'LIMIT' | 'TWAP' | 'BLOCK' | 'VWAP' | 'STOP_LIMIT' | 'PEG';
+  base_quantity?: string;
+  quote_value?: string;
+  limit_price?: string;
+  stop_price?: string;
+  start_time?: string;
+  expiry_time?: string;
+  time_in_force?:
+    | 'FILL_OR_KILL'
+    | 'GOOD_UNTIL_DATE_TIME'
+    | 'GOOD_UNTIL_CANCELLED'
+    | 'IMMEDIATE_OR_CANCEL';
+  is_raise_exact?: boolean;
+  historical_pov?: string;
+  peg_offset_type?:
+    | 'PEG_OFFSET_TYPE_PRICE'
+    | 'PEG_OFFSET_TYPE_BPS'
+    | 'PEG_OFFSET_TYPE_BASIS_POINTS'
+    | 'PEG_OFFSET_TYPE_DEPTH'
+    | 'PEG_OFFSET_TYPE_CUMULATIVE_DEPTH_IN_BASE_UNITS';
+  offset?: string;
+  wig_level?: string;
+}
+⋮----
+export interface GetPrimePortfolioOrdersRequest {
+  portfolio_id: string;
+  order_statuses?: (
+    | 'FILLED'
+    | 'CANCELLED'
+    | 'EXPIRED'
+    | 'FAILED'
+    | 'PENDING'
+  )[];
+  product_ids?: string[];
+  order_type?:
+    | 'MARKET'
+    | 'LIMIT'
+    | 'TWAP'
+    | 'BLOCK'
+    | 'VWAP'
+    | 'STOP_LIMIT'
+    | 'PEG';
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+  order_side?: 'BUY' | 'SELL';
+  start_date?: string;
+  end_date?: string;
+}
+⋮----
+export interface GetPrimeOrderFillsRequest {
+  portfolio_id: string;
+  order_id: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+}
+/**
+ *
+ * Products Endpoints
+ *
+ */
+⋮----
+export interface GetPrimePortfolioProductsRequest {
+  portfolio_id: string;
+  cursor?: string;
+  /** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+  /** If unset, returns all product types available for the portfolio (including FUTURE). */
+  product_type?: 'SPOT' | 'FUTURE' | 'OPTION';
+  /** Only applicable when product_type = FUTURE. */
+  contract_expiry_type?:
+    | 'CONTRACT_EXPIRY_TYPE_EXPIRING'
+    | 'CONTRACT_EXPIRY_TYPE_PERPETUAL';
+  /** Filter by expiry status for expiring futures. */
+  expiring_contract_status?:
+    | 'EXPIRING_CONTRACT_STATUS_UNEXPIRED'
+    | 'EXPIRING_CONTRACT_STATUS_EXPIRED'
+    | 'EXPIRING_CONTRACT_STATUS_ALL';
+}
+⋮----
+/** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
+⋮----
+/** If unset, returns all product types available for the portfolio (including FUTURE). */
+⋮----
+/** Only applicable when product_type = FUTURE. */
+⋮----
+/** Filter by expiry status for expiring futures. */
+⋮----
+/**
+ *
+ * Travel Rule Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeTransactionTravelRuleDataRequest {
+  portfolio_id: string;
+  transaction_id: string;
+}
+⋮----
+/**
+ *
+ * Transactions Endpoints
+ *
+ */
+⋮----
+export interface GetPrimePortfolioTransactionsRequest {
+  portfolio_id: string;
+  symbols?: string[];
+  types?: string[];
+  start_time?: string;
+  end_time?: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+}
+⋮----
+export interface CreatePrimeConversionRequest {
+  portfolio_id: string;
+  wallet_id: string;
+  amount: string;
+  destination: string;
+  idempotency_key: string;
+  source_symbol: string;
+  destination_symbol: string;
+}
+⋮----
+export interface GetPrimeWalletTransactionsRequest {
+  portfolio_id: string;
+  wallet_id: string;
+  types?: string[];
+  start_time?: string;
+  end_time?: string;
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+}
+⋮----
+export interface CreatePrimeTransferRequest {
+  portfolio_id: string;
+  wallet_id: string;
+  amount: string;
+  destination: string;
+  idempotency_key: string;
+  currency_symbol: string;
+}
+⋮----
+export interface CreatePrimeWithdrawalRequest {
+  portfolio_id: string;
+  wallet_id: string;
+  amount: string;
+  destination_type: 'DESTINATION_PAYMENT_METHOD' | 'DESTINATION_BLOCKCHAIN';
+  idempotency_key: string;
+  currency_symbol: string;
+  payment_method?: {
+    payment_method_id: string;
+  };
+  blockchain_address?: {
+    address: string;
+    account_identifier?: string;
+  };
+}
+/**
+ *
+ * Wallets Endpoints
+ *
+ */
+⋮----
+export interface GetPrimePortfolioWalletsRequest {
+  portfolio_id: string;
+  type: 'VAULT' | 'TRADING' | 'WALLET_TYPE_OTHER' | 'WEB3';
+  cursor?: string;
+  limit?: number;
+  sort_direction?: 'DESC' | 'ASC';
+  symbols?: string[];
+}
+⋮----
+export interface CreatePrimeWalletRequest {
+  portfolio_id: string;
+  name: string;
+  symbol: string;
+  wallet_type: 'VAULT' | 'TRADING' | 'WALLET_TYPE_OTHER' | 'WEB3';
+}
+⋮----
+export interface GetPrimeWalletDepositInstructionsRequest {
+  portfolio_id: string;
+  wallet_id: string;
+  deposit_type?:
+    | 'UNKNOWN_WALLET_DEPOSIT_TYPE'
+    | 'CRYPTO'
+    | 'WIRE'
+    | 'SEN'
+    | 'SWIFT';
+}
+⋮----
+/**
+ *
+ * Financing Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeEntityAccrualsRequest {
+  entity_id: string;
+  portfolio_id?: string;
+  start_date?: string;
+  end_date?: string;
+}
+⋮----
+export interface GetPrimeEntityLocateAvailabilitiesRequest {
+  entity_id: string;
+  conversion_date?: string;
+  locate_date?: string;
+}
+⋮----
+export interface GetPrimeEntityMarginSummariesRequest {
+  entity_id: string;
+  start_date?: string;
+  end_date?: string;
+}
+⋮----
+export interface GetPrimeEntityTFTieredFeesRequest {
+  entity_id: string;
+  effective_at?: string;
+}
+⋮----
+export interface GetPrimePortfolioAccrualsRequest {
+  portfolio_id: string;
+  start_date?: string;
+  end_date?: string;
+}
+⋮----
+export interface GetPrimePortfolioBuyingPowerRequest {
+  portfolio_id: string;
+  base_currency: string;
+  quote_currency: string;
+}
+⋮----
+export interface GetPrimePortfolioLocatesRequest {
+  portfolio_id: string;
+  locate_ids?: string[];
+  conversion_date?: string;
+  locate_date?: string;
+}
+⋮----
+export interface GetPrimePortfolioMarginConversionsRequest {
+  portfolio_id: string;
+  start_date?: string;
+  end_date?: string;
+}
+⋮----
+export interface GetPrimePortfolioWithdrawalPowerRequest {
+  portfolio_id: string;
+  symbol: string;
+}
+
+================
 File: src/CBPrimeClient.ts
 ================
 import { AxiosRequestConfig } from 'axios';
@@ -8295,7 +8288,6 @@ import {
   RotatePrimeApiKeyRequest,
   SubmitPrimeOrderRequest,
 } from './types/request/coinbase-prime.js';
-import { GetPrimeTransactionTravelRuleDataResponse } from './types/response/coinbase-prime.js';
 ⋮----
 /**
  * REST client for Coinbase Prime API:
@@ -8823,7 +8815,7 @@ getTransactionById(params: {
    */
 getTransactionTravelRuleData(
     params: GetPrimeTransactionTravelRuleDataRequest,
-): Promise<GetPrimeTransactionTravelRuleDataResponse>
+): Promise<any>
 ⋮----
 /**
    * Create Conversion
@@ -8893,53 +8885,6 @@ getWalletById(params: {
 getWalletDepositInstructions(
     params: GetPrimeWalletDepositInstructionsRequest,
 ): Promise<any>
-
-================
-File: LICENSE.md
-================
-Copyright 2025 Tiago Siebler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-================
-File: tsconfig.json
-================
-{
-  "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
-    "noEmitOnError": true,
-    "declaration": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": false,
-    "inlineSourceMap": false,
-    "lib": ["esnext"],
-    "listEmittedFiles": false,
-    "listFiles": false,
-    "moduleResolution": "node",
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitAny": true,
-    "noUnusedParameters": true,
-    "pretty": true,
-    "removeComments": false,
-    "resolveJsonModule": true,
-    "skipLibCheck": false,
-    "sourceMap": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "types": ["node", "jest"],
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "compileOnSave": true,
-  "exclude": ["node_modules", "dist"],
-  "include": ["src/**/*.*", "test/**/*.*", ".eslintrc.cjs"]
-}
 
 ================
 File: webpack/webpack.config.cjs

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,8 @@ Notes:
 ================================================================
 Directory Structure
 ================================================================
+docs/
+  COINBASE_SDK_QUICKSTART_GUIDE.md
 examples/
   AdvancedTrade/
     Private/
@@ -146,6 +148,221 @@ Files
 ================================================================
 
 ================
+File: examples/AdvancedTrade/Private/closePosition.ts
+================
+import { CBAdvancedTradeClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+// this function is suggested to used with spot market orders
+// If you want to close futures, it is recommended to use submitOrder() with the opposite side of the current position
+⋮----
+/* Closing Futures Positions - Exchange docs
+When a contract expires, we automatically close your open position at the exchange settlement price.
+You can also close your position before the contract expires
+(for example, you may want to close your position if you’ve reached your profit target,
+you want to prevent further losses, or you need to satisfy a margin requirement).
+
+There are two ways to close your futures positions:
+(1) Close your position with this endpoint, or
+(2) Create a separate trade to take the opposite position in the same futures contract you are currently holding in your account.
+For example, to close an open long position in the BTC 23 Feb 24 contract, place an order to sell the same number of BTC 23 Feb 24 contracts.
+If you were short to begin with, go long the same number of contracts to close your position.
+
+More info on https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_closeposition#closing-futures-positions */
+⋮----
+async function closePosition()
+⋮----
+// close position
+⋮----
+//
+
+================
+File: examples/AdvancedTrade/Private/getAccounts.ts
+================
+import { CBAdvancedTradeClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function getAccounts()
+⋮----
+// Get all accounts
+⋮----
+// Get specific account details
+
+================
+File: examples/AdvancedTrade/Private/getOrders.ts
+================
+import { CBAdvancedTradeClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function getOrders()
+⋮----
+// Get all orders
+⋮----
+// Get order details
+
+================
+File: examples/AdvancedTrade/Private/submitOrderPerps.ts
+================
+import { CBAdvancedTradeClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function submitOrder()
+⋮----
+// submit market futures order
+⋮----
+//
+⋮----
+async function submitLimitOrder()
+⋮----
+// Submit limit futures order
+
+================
+File: examples/AdvancedTrade/Private/submitOrderSpot.ts
+================
+import { CBAdvancedTradeClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function submitOrder()
+⋮----
+// submit market spot order
+⋮----
+//
+⋮----
+async function submitLimitOrder()
+⋮----
+// Submit limit spot order
+
+================
 File: examples/AdvancedTrade/Public/advanced-public-rest-all.ts
 ================
 import { CBAdvancedTradeClient } from '../../../src/index.js';
@@ -170,6 +387,127 @@ async function publicCalls()
 // Get public product candles
 ⋮----
 // Get public market trades
+
+================
+File: examples/AdvancedTrade/WebSockets/privateWs.ts
+================
+import {
+  // DefaultLogger,
+  WebsocketClient,
+  // WS_KEY_MAP,
+  WsTopicRequest,
+} from '../../../src/index.js';
+⋮----
+// DefaultLogger,
+⋮----
+// WS_KEY_MAP,
+⋮----
+/**
+ * import { WebsocketClient } from 'coinbase-api';
+ * const { WebsocketClient } = require('coinbase-api');
+ */
+⋮----
+async function start()
+⋮----
+// key name & private key, as returned by coinbase when creating your API keys.
+// Note: the below example is a dummy key and won't actually work
+⋮----
+// Optional: fully customise the logging experience by injecting a custom logger
+// const logger: typeof DefaultLogger = {
+//   ...DefaultLogger,
+//   trace: (...params) => {
+//     if (
+//       [
+//         'Sending ping',
+//         'Sending upstream ws message: ',
+//         'Received pong, clearing pong timer',
+//         'Received ping, sending pong frame',
+//       ].includes(params[0])
+//     ) {
+//       return;
+//     }
+//     console.log('trace', params);
+//   },
+// };
+⋮----
+// Either pass the full JSON object that can be downloaded when creating your API keys
+// cdpApiKey: advancedTradeCdpAPIKey,
+⋮----
+// initialise the client
+/**
+       *
+       * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+       *
+       * ECDSA:
+       *
+       * {
+       *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+       *   apiSecret:
+       *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+       * }
+       *
+       * ED25519:
+       * {
+       *   apiKey: 'your-api-key-id',
+       *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+       * }
+       *
+       *
+       */
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+/**
+     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
+     *
+     * You can subscribe to topics one at a time or many one one request.
+     *
+     * Topics can be sent as simple strings, if no parameters are required.
+     *
+     * Any subscribe requests on the "advTradeUserData" market are automatically authenticated with the available credentials
+     */
+// client.subscribe('heartbeats', 'advTradeUserData');
+⋮----
+// This is the same as above, but uses WS_KEY_MAP as an enum (do this if you're not sure what value to put)
+// client.subscribe('futures_balance_summary', WS_KEY_MAP.advTradeUserData);
+⋮----
+// Subscribe to the user feed for the advanced trade websocket
+⋮----
+// /**
+//  * Or, as an array of simple strings.
+//  *
+//  * Any requests sent to the "advTradeUserData" wsKey are
+//  * automatically authenticated, if API keys are avaiable:
+//  */
+// client.subscribe(
+//   ['futures_balance_summary', 'user'],
+//   'advTradeUserData',
+// );
+⋮----
+/**
+     * Or send a more structured object with parameters, e.g. if parameters are required
+     */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+⋮----
+/**
+       * Anything in the payload will be merged into the subscribe "request",
+       * allowing you to send misc parameters supported by the exchange (such as `product_ids: string[]`)
+       */
+⋮----
+// In this case, the "futures_balance_summary" channel doesn't support any parameters
+// product_ids: ['ETH-USD', 'BTC-USD'],
 
 ================
 File: examples/AdvancedTrade/WebSockets/publicWs.ts
@@ -267,6 +605,192 @@ async function start()
 /**
      * Other adv trade public websocket topics:
      */
+
+================
+File: examples/CoinbaseApp/Private/cb-app-private.ts
+================
+/**
+ * import { CBAppClient } from 'coinbase-api';
+ * const { CBAppClient } = require('coinbase-api');
+ */
+⋮----
+import { CBAppClient } from '../../../src/index.js';
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function main()
+⋮----
+// Deposit funds to your fiat account
+⋮----
+// Withdraw funds from fiat account
+⋮----
+// Send money to another user
+⋮----
+// Transfer money between your own accounts
+
+================
+File: examples/CoinbaseApp/Private/depositFunds.ts
+================
+import { CBAppClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAppClient } from 'coinbase-api';
+ * const { CBAppClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function depositFunds()
+⋮----
+// Deposit funds to your fiat account
+
+================
+File: examples/CoinbaseApp/Private/sendMoney.ts
+================
+import { CBAppClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAppClient } from 'coinbase-api';
+ * const { CBAppClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function sendMoney()
+⋮----
+// Send money to another user
+
+================
+File: examples/CoinbaseApp/Private/transferMoney.ts
+================
+import { CBAppClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAppClient } from 'coinbase-api';
+ * const { CBAppClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function transferMoney()
+⋮----
+// Transfer money between your own accounts
+
+================
+File: examples/CoinbaseApp/Private/withdrawFunds.ts
+================
+import { CBAppClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBAppClient } from 'coinbase-api';
+ * const { CBAppClient } = require('coinbase-api');
+ */
+⋮----
+// initialise the client
+/**
+ *
+ * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
+ *
+ * ECDSA:
+ *
+ * {
+ *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
+ *   apiSecret:
+ *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
+ * }
+ *
+ * ED25519:
+ * {
+ *   apiKey: 'your-api-key-id',
+ *   apiSecret: 'yourExampleApiSecretEd25519Version==',
+ * }
+ *
+ *
+ */
+⋮----
+async function withdrawFunds()
+⋮----
+// Withdraw funds from your fiat account
 
 ================
 File: examples/CoinbaseApp/Public/cbapp-public-rest-all.ts
@@ -652,9 +1176,2963 @@ export interface WsStoredState<TWSTopicSubscribeEvent extends string | object> {
 /** To reauthenticate on the WS API, which channel do we send to? */
 
 ================
+File: src/lib/jwtNode.ts
+================
+import { createPrivateKey } from 'crypto';
+import { importPKCS8, SignJWT } from 'jose';
+import { nanoid } from 'nanoid';
+⋮----
+interface JWTSignParams {
+  algorithm?: 'ES256' | 'EdDSA';
+  timestampMs: number;
+  jwtExpiresSeconds: number;
+  apiPubKey: string;
+  apiPrivKey: string;
+}
+⋮----
+interface KeyInfo {
+  algorithm: 'ES256' | 'EdDSA';
+  privateKey: string;
+}
+⋮----
+/**
+ * Auto-detect key type and format based on the private key content
+ */
+function detectKeyTypeAndFormat(privateKeyPem: string): KeyInfo
+⋮----
+// ECDSA key detection (PEM format)
+⋮----
+// Ed25519 key detection (base64 string without PEM headers)
+// Ed25519 private keys from Coinbase are provided as base64-encoded PKCS#8 keys
+⋮----
+// Try to decode as base64 to validate it's a valid base64 string
+⋮----
+// Ed25519 PKCS#8 keys are typically 48 bytes (44 bytes + padding)
+// Raw Ed25519 keys are 32 bytes, but Coinbase provides PKCS#8 encoded keys
+⋮----
+// Convert base64 Ed25519 key to PEM format for jose
+⋮----
+// Not a valid base64 string, fall through
+⋮----
+// Default to ECDSA if we can't determine the type
+⋮----
+/**
+ * Convert EC private key to PKCS#8 format if needed
+ */
+function ensurePKCS8Format(privateKeyPem: string): string
+⋮----
+// Convert EC private key to PKCS#8 format
+⋮----
+/**
+ * Convert base64 Ed25519 private key to PKCS#8 format
+ */
+function convertEd25519ToPKCS8(base64Key: string): string
+⋮----
+// Handle different Ed25519 key formats
+⋮----
+// Raw 32-byte Ed25519 private key
+⋮----
+// libsodium format: 32 bytes private key + 32 bytes public key
+// Extract just the private key (first 32 bytes)
+⋮----
+// Already PKCS#8 encoded, convert to PEM
+⋮----
+// Validate the key
+⋮----
+// Create PKCS#8 DER encoding for Ed25519 private key
+// PKCS#8 structure for Ed25519:
+// SEQUENCE {
+//   INTEGER 0 (version)
+//   SEQUENCE {
+//     OBJECT IDENTIFIER 1.3.101.112 (Ed25519)
+//   }
+//   OCTET STRING {
+//     OCTET STRING privateKey (32 bytes)
+//   }
+// }
+⋮----
+const ed25519Oid = Buffer.from([0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70]); // Ed25519 OID
+⋮----
+Buffer.from([0x04, 0x22, 0x04, 0x20]), // OCTET STRING header + inner OCTET STRING header
+⋮----
+Buffer.from([0x30, 0x2e]), // SEQUENCE, total length 46 bytes
+Buffer.from([0x02, 0x01, 0x00]), // INTEGER 0 (version)
+ed25519Oid, // Algorithm identifier
+privateKeyOctetString, // Private key
+⋮----
+// Convert to PEM format
+⋮----
+// Validate the generated key
+⋮----
+export async function signJWT(
+  params: {
+    url: string;
+    method: string;
+  } & JWTSignParams,
+): Promise<string>
+⋮----
+// Remove https:// but keep the rest
+⋮----
+// Auto-detect key type and format, or use provided algorithm
+⋮----
+// Import the private key
+⋮----
+// Create and sign the JWT
+⋮----
+export async function signWSJWT(params: JWTSignParams): Promise<string>
+⋮----
+// Auto-detect key type and format, or use provided algorithm
+⋮----
+// Import the private key
+⋮----
+// Create and sign the JWT
+
+================
 File: src/lib/misc-util.ts
 ================
 export function neverGuard(x: never, msg: string): Error
+
+================
+File: src/lib/webCryptoAPI.ts
+================
+import { neverGuard } from './misc-util.js';
+⋮----
+function bufferToB64(buffer: ArrayBuffer): string
+⋮----
+function b64StringToBuffer(input: string): Uint8Array
+⋮----
+const binaryString = atob(input); // Decode base64 string
+⋮----
+// Convert binary string to a Uint8Array
+⋮----
+export type SignEncodeMethod = 'hex' | 'base64';
+export type SignAlgorithm = 'SHA-256' | 'SHA-512';
+⋮----
+/**
+ * Similar to node crypto's `createHash()` function
+ */
+export async function hashMessage(
+  message: string,
+  method: SignEncodeMethod,
+  algorithm: SignAlgorithm,
+): Promise<string>
+⋮----
+/**
+ * Sign a message, with a secret, using the Web Crypto API
+ */
+export async function signMessage(
+  message: string,
+  secret: string,
+  method: SignEncodeMethod,
+  algorithm: SignAlgorithm,
+  secretEncodeMethod: 'base64:web' | 'utf',
+): Promise<string>
+⋮----
+// case 'base64:node': {
+//   encodedSecret = Buffer.from(secret, 'base64');
+//   break;
+// }
+
+================
+File: src/types/request/coinbase-app-client.ts
+================
+/**
+ *
+ * Account Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Address Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Transactions Endpoints
+ *
+ */
+⋮----
+export interface CBAppBeneficiaryAddress {
+  address1: string;
+  address2?: string;
+  address3?: string;
+  city?: string;
+  state?: string;
+  country?: string; // ISO 3166-1 alpha-2 country code
+  postal_code?: string;
+}
+⋮----
+country?: string; // ISO 3166-1 alpha-2 country code
+⋮----
+export interface CBAppTravelRuleData {
+  beneficiary_wallet_type: 'WALLET_TYPE_SELF_HOSTED' | 'WALLET_TYPE_EXCHANGE';
+  is_self: 'IS_SELF_FALSE' | 'IS_SELF_TRUE';
+  beneficiary_name: string;
+  beneficiary_address: CBAppBeneficiaryAddress;
+  beneficiary_financial_institution: string;
+  transfer_purpose: string;
+}
+⋮----
+export interface CBAppSendMoneyRequest {
+  account_id: string;
+  type: 'send';
+  to: string;
+  amount: string;
+  currency: string;
+  description?: string;
+  skip_notifications?: boolean;
+  idem?: string;
+  destination_tag?: string;
+  network?: string;
+  travel_rule_data?: CBAppTravelRuleData;
+}
+⋮----
+export interface CBAppTransferMoneyRequest {
+  account_id: string;
+  type: 'transfer';
+  to: string;
+  amount: string;
+  currency: string;
+  description?: string;
+}
+/**
+ *
+ * Deposits Endpoints
+ *
+ */
+⋮----
+export interface CBAppDepositFundsRequest {
+  account_id: string;
+  amount: string;
+  currency: string;
+  payment_method: string;
+  commit?: boolean;
+}
+⋮----
+/**
+ *
+ * Withdrawals Endpoints
+ *
+ */
+⋮----
+export interface CBAppWithdrawFundsRequest {
+  account_id: string;
+  amount: string;
+  currency: string;
+  payment_method: string;
+  commit?: boolean;
+}
+⋮----
+/**
+ *
+ * DATA - Currencies Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA- Exchange rates Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA - Prices Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA - Time Endpoints
+ *
+ */
+
+================
+File: src/types/response/coinbase-app-client.ts
+================
+export interface CBAppPagination {
+  ending_before?: string | null;
+  starting_after?: string | null;
+  limit?: number;
+  order?: string;
+  previous_uri: string | null;
+  next_uri: string | null;
+}
+⋮----
+/**
+ *
+ * Account Endpoints
+ *
+ */
+⋮----
+interface AccountCurrency {
+  address_regex: string;
+  asset_id: string;
+  code: string;
+  color: string;
+  exponent: number;
+  name: string;
+  slug: string;
+  sort_index: number;
+  type: string;
+}
+⋮----
+interface AccountBalance {
+  amount: string;
+  currency: string;
+}
+⋮----
+export interface CBAppAccount {
+  id: string;
+  name: string;
+  primary: boolean;
+  type: string;
+  currency: AccountCurrency;
+  balance: AccountBalance;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+  ready: boolean;
+}
+⋮----
+/**
+ *
+ * Address Endpoints
+ *
+ */
+⋮----
+export interface CBAppAddress {
+  id: string;
+  address: string;
+  name?: string;
+  network: string;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+}
+⋮----
+/**
+ *
+ * Transactions Endpoints
+ *
+ */
+⋮----
+interface TransactionAmount {
+  amount: string;
+  currency: string;
+}
+⋮----
+interface TransactionNetwork {
+  status: string;
+  name: string;
+  hash?: string;
+  transaction_fee?: TransactionAmount;
+  transaction_amount?: TransactionAmount;
+  network_name?: string;
+  status_description?: string | null;
+}
+⋮----
+interface TransactionFrom {
+  id: string;
+  resource: string;
+  resource_path?: string;
+}
+⋮----
+interface TransactionTo {
+  resource: string;
+  address?: string;
+  email?: string;
+  id?: string;
+  resource_path?: string;
+}
+⋮----
+interface TransactionDetails {
+  title: string;
+  subtitle: string;
+  header?: string;
+  health?: string;
+  subsidebar_label?: string | null;
+}
+⋮----
+interface AdvancedTradeFill {
+  fill_price: string;
+  product_id: string;
+  order_id: string;
+  commission: string;
+  order_side: 'BUY' | 'SELL';
+}
+⋮----
+export interface CBAppTransaction {
+  id: string;
+  type: string;
+  status: string;
+  amount: TransactionAmount;
+  native_amount: TransactionAmount;
+  description: string | null;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+  network?: TransactionNetwork;
+  from?: TransactionFrom;
+  to?: TransactionTo;
+  details?: TransactionDetails;
+  instant_exchange?: boolean;
+  advanced_trade_fill?: AdvancedTradeFill;
+  cancelable?: boolean;
+  idem?: string;
+}
+⋮----
+/**
+ *
+ * Deposits/Withdrawal Endpoints
+ *
+ */
+⋮----
+interface DepositWithdrawalPaymentMethod {
+  id: string;
+  resource: string;
+  resource_path: string;
+}
+⋮----
+interface DepositWithdrawalTransaction {
+  id: string;
+  resource: string;
+  resource_path: string;
+}
+⋮----
+interface DepositWithdrawalAmountCurrency {
+  amount: string;
+  currency: string;
+}
+⋮----
+export interface CBAppDepositWithdrawal {
+  id: string;
+  status: string;
+  payment_method: DepositWithdrawalPaymentMethod;
+  transaction: DepositWithdrawalTransaction;
+  amount: DepositWithdrawalAmountCurrency;
+  subtotal: DepositWithdrawalAmountCurrency;
+  created_at: string;
+  updated_at: string;
+  resource: string;
+  resource_path: string;
+  committed: boolean;
+  fee: DepositWithdrawalAmountCurrency;
+  payout_at: string;
+}
+⋮----
+interface TransferAmount {
+  value: string;
+  currency: string;
+}
+⋮----
+interface TransferOwner {
+  id: string;
+  uuid: string;
+  user_uuid: string;
+  type: string;
+}
+⋮----
+interface TransferLedgerAccount {
+  account_id: string;
+  currency: string;
+  owner: TransferOwner;
+}
+⋮----
+interface TransferExternalPaymentMethod {
+  payment_method_id: string;
+}
+⋮----
+interface TransferSource {
+  type: string;
+  network: string;
+  payment_method_id: string;
+  external_payment_method: TransferExternalPaymentMethod;
+}
+⋮----
+interface TransferTarget {
+  type: string;
+  network: string;
+  payment_method_id: string;
+  ledger_account: TransferLedgerAccount;
+}
+⋮----
+interface TransferFee {
+  title: string;
+  description: string;
+  amount: TransferAmount;
+  type: string;
+}
+⋮----
+export interface CBAppTransferDepositWithdrawal {
+  user_entered_amount: TransferAmount;
+  amount: TransferAmount;
+  total: TransferAmount;
+  subtotal: TransferAmount;
+  idem: string;
+  committed: boolean;
+  id: string;
+  instant: boolean;
+  source: TransferSource;
+  target: TransferTarget;
+  payout_at: string;
+  status: string;
+  user_reference: string;
+  type: string;
+  created_at: string | null;
+  updated_at: string | null;
+  user_warnings: any[];
+  fees: any[];
+  total_fee: TransferFee;
+  cancellation_reason: string | null;
+  hold_days: number;
+  nextStep: any | null;
+  checkout_url: string;
+  requires_completion_step: boolean;
+}
+⋮----
+export interface CBAppTransfer {
+  transfer: CBAppTransferDepositWithdrawal;
+}
+/**
+ *
+ * Subscriptions Endpoints
+ *
+ */
+⋮----
+export interface CBAppCoinbaseOneSubscription {
+  status: string;
+  tier: string;
+  current_period_end: string;
+}
+⋮----
+/**
+ *
+ * DATA - Currencies Endpoints
+ *
+ */
+⋮----
+export interface CBAppFiatCurrency {
+  id: string;
+  name: string;
+  min_size: string;
+}
+⋮----
+export interface CBAppCryptocurrency {
+  code: string;
+  name: string;
+  color: string;
+  sort_index: number;
+  exponent: number;
+  type: string;
+  address_regex: string;
+  asset_id: string;
+}
+⋮----
+/**
+ *
+ * DATA- Exchange rates Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA - Prices Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * DATA - Time Endpoints
+ *
+ */
+
+================
+File: src/types/response/coinbase-international.ts
+================
+/**
+ *
+ * Assets Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Instruments Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Position Offsets Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Orders Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Portfolios Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Rankings Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Transfers Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Fee Rates Endpoints
+ *
+ */
+
+================
+File: src/types/response/coinbase-prime.ts
+================
+/**
+ *
+ * Allocation Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Invoice Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Assets Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Payment Methods Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Users Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Portfolios Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Activities Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Address Book Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Balances Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Commission Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Orders Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Products Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Transactions Endpoints
+ *
+ */
+⋮----
+/**
+ *
+ * Travel Rule Endpoints
+ *
+ */
+⋮----
+export interface PrimeTravelRuleDetailedAddress {
+  address_1?: string;
+  address_2?: string;
+  address_3?: string;
+  city?: string;
+  state?: string;
+  country_code?: string;
+  postal_code?: string;
+}
+⋮----
+export interface PrimeTravelRuleNaturalPersonName {
+  first_name?: string;
+  middle_name?: string;
+  last_name?: string;
+}
+⋮----
+export interface PrimeTravelRuleParty {
+  name?: string;
+  natural_person_name?: PrimeTravelRuleNaturalPersonName;
+  address?: PrimeTravelRuleDetailedAddress;
+  wallet_type?:
+    | 'TRAVEL_RULE_WALLET_TYPE_VASP'
+    | 'TRAVEL_RULE_WALLET_TYPE_SELF_CUSTODIED';
+  vasp_id?: string;
+  vasp_name?: string;
+  personal_id?: string;
+  date_of_birth?: {
+    year?: number;
+    month?: number;
+    day?: number;
+  };
+  telephone_number?: string;
+  account_id?: string;
+  vasp_address?: PrimeTravelRuleDetailedAddress;
+}
+⋮----
+export interface GetPrimeTransactionTravelRuleDataResponse {
+  fulfilled: boolean;
+  is_self?: boolean;
+  originator?: PrimeTravelRuleParty;
+  beneficiary?: PrimeTravelRuleParty;
+  amount?: string;
+  amount_currency?: string;
+  fiat_amount?: string;
+  fiat_amount_currency?: string;
+  blockchain_network?: string;
+}
+⋮----
+/**
+ *
+ * Wallets Endpoints
+ *
+ */
+
+================
+File: src/types/response/ws.ts
+================
+export interface WsInfo {
+  endpoint: string;
+  encrypt: boolean;
+  protocol: string;
+  pingInterval: number;
+  pingTimeout: number;
+}
+
+================
+File: src/types/websockets/events.ts
+================
+import { WS_KEY_MAP } from '../../lib/websocket/websocket-util.js';
+⋮----
+export interface WsDataEvent<TData = any, TWSKey = string> {
+  data: TData;
+  table: string;
+  wsKey: TWSKey;
+}
+⋮----
+/**
+ * General event structure for events from the advanced trade websocket
+ */
+export interface CBAdvancedTradeEvent {
+  channel: string;
+  client_id: string;
+  timestamp: string;
+  sequence_num: number;
+  events: Record<'subscriptions', Record<string, string[]>>;
+}
+⋮----
+export interface CBAdvancedTradeErrorEvent {
+  type: 'error';
+  message: string;
+  wsKey:
+    | typeof WS_KEY_MAP.advTradeMarketData
+    | typeof WS_KEY_MAP.advTradeUserData;
+}
+⋮----
+/**
+ * General event structure for events from the Coinbase Exchange websocket.
+ * All Coinbase Exchange events extend this schema.
+ */
+export interface CBExchangeBaseEvent {
+  type: 'subscriptions' | string;
+  wsKey:
+    | typeof WS_KEY_MAP.exchangeMarketData
+    | typeof WS_KEY_MAP.exchangeDirectMarketData;
+}
+⋮----
+/**
+ * Sent after subscribing to one or more channels
+ */
+export type CBExchangeSubscriptionsEvent = CBExchangeBaseEvent & {
+  type: 'subscriptions';
+  channels?: { name: string; product_ids: string[]; account_ids: null }[];
+};
+
+================
+File: src/types/websockets/requests.ts
+================
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export type WsOperation = 'subscribe' | 'unsubscribe';
+⋮----
+/**
+ * This is the format used for commands sent upstream for this websocket connection.
+ *
+ * Docs:
+ * - Adv Trade: https://docs.cdp.coinbase.com/advanced-trade/docs/ws-auth#subscribing
+ */
+export interface WsAdvTradeRequestOperation<TWSTopic extends string = string> {
+  type: WsOperation;
+  channel: TWSTopic;
+  product_ids?: string[];
+  jwt?: string;
+}
+⋮----
+export interface WsExchangeChannelWithParams<TWSTopic extends string = string> {
+  name: TWSTopic;
+  product_ids: string[];
+}
+⋮----
+/**
+ * Public subscribe/unsubscribe requests for the Coinbase Exchange product group
+ */
+export interface WsExchangeRequestOperation<TWSTopic extends string = string> {
+  type: WsOperation;
+  channels: (TWSTopic | WsExchangeChannelWithParams)[];
+  product_ids?: string[];
+}
+⋮----
+/**
+ * Private (authenticated) subscribe/unsubscribe requests for the Coinbase Exchange product group
+ * https://docs.cdp.coinbase.com/exchange/docs/websocket-auth
+ */
+export type WsExchangeAuthenticatedRequestOperation<
+  TWSTopic extends string = string,
+> = WsExchangeRequestOperation<TWSTopic> & {
+  signature: string;
+  key: string;
+  passphrase: string;
+  timestamp: string;
+};
+⋮----
+/**
+ * Public subscribe/unsubscribe requests for the Coinbase International product group
+ */
+export interface WsInternationalRequestOperation<
+  TWSTopic extends string = string,
+> {
+  type: Uppercase<WsOperation>;
+  channels: TWSTopic[];
+  product_ids?: string[];
+}
+⋮----
+/**
+ * Private (authenticated) subscribe/unsubscribe requests for the Coinbase International product group
+ * https://docs.cdp.coinbase.com/intx/docs/websocket-auth
+ */
+export type WsInternationalAuthenticatedRequestOperation<
+  TWSTopic extends string = string,
+> = WsInternationalRequestOperation<TWSTopic> & {
+  time: string;
+  key: string;
+  passphrase: string;
+  signature: string;
+};
+⋮----
+/**
+ * Public subscribe/unsubscribe requests for the Coinbase Prime product group
+ */
+export interface WsPrimeRequestOperation<TWSTopic extends string = string> {
+  type: WsOperation;
+  channel: TWSTopic;
+  // these should be provided as a payload with the request, else auth will fail
+  svcAccountId: string;
+  portfolio_id: string;
+  product_ids: string[];
+}
+⋮----
+// these should be provided as a payload with the request, else auth will fail
+⋮----
+/**
+ * Private (authenticated) subscribe/unsubscribe requests for the Coinbase Prime product group
+ *
+ * - https://docs.cdp.coinbase.com/prime/docs/websocket-feed#signing-messages
+ * - https://docs.cdp.coinbase.com/prime/docs/websocket-channels
+ */
+export type WsPrimeAuthenticatedRequestOperation<
+  TWSTopic extends string = string,
+> = WsPrimeRequestOperation<TWSTopic> & {
+  access_key: string;
+  api_key_id: string;
+  passphrase: string;
+  signature: string;
+  timestamp: string;
+};
+
+================
+File: src/types/websockets/wsAPI.ts
+================
+export interface WsAPIWsKeyTopicMap {
+  [k: string]: never;
+}
+⋮----
+export interface WsAPITopicRequestParamMap {
+  [k: string]: never;
+}
+⋮----
+export interface WsAPITopicResponseMap {
+  [k: string]: never;
+}
+
+================
+File: src/CBAppClient.ts
+================
+import { AxiosRequestConfig } from 'axios';
+⋮----
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import {
+  getParamsFromURL,
+  REST_CLIENT_TYPE_ENUM,
+  RestClientOptions,
+  RestClientType,
+} from './lib/requestUtils.js';
+import {
+  CBAppDepositFundsRequest,
+  CBAppSendMoneyRequest,
+  CBAppTransferMoneyRequest,
+  CBAppWithdrawFundsRequest,
+} from './types/request/coinbase-app-client.js';
+import {
+  CBAppAccount,
+  CBAppAddress,
+  CBAppCoinbaseOneSubscription,
+  CBAppCryptocurrency,
+  CBAppDepositWithdrawal,
+  CBAppFiatCurrency,
+  CBAppPagination,
+  CBAppTransaction,
+  CBAppTransfer,
+} from './types/response/coinbase-app-client.js';
+⋮----
+/**
+ * REST client for Coinbase's Coinbase App API:
+ * https://docs.cdp.coinbase.com/coinbase-app/docs/welcome
+ */
+export class CBAppClient extends BaseRestClient
+⋮----
+constructor(
+    restClientOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {},
+)
+⋮----
+// Some endpoints return a warning if a version header isn't included: https://docs.cdp.coinbase.com/coinbase-app/docs/versioning
+// Currently set to a date from the changelog: https://docs.cdp.coinbase.com/coinbase-app/docs/changelog
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * Account Endpoints
+   *
+   */
+⋮----
+/**
+   * List Accounts
+   *
+   * List a current user's accounts to which the authentication method has access to.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of accounts.
+   */
+getAccounts(params?: {
+    paginationURL?: string;
+    starting_after?: string;
+}): Promise<
+⋮----
+/**
+   * Show Account
+   *
+   * Get a current user's account by account ID or currency string.
+   */
+getAccount(params:
+⋮----
+/**
+   *
+   * Address Endpoints
+   *
+   */
+⋮----
+/**
+   * Create Address
+   *
+   * Creates a new address for an account. Addresses can be created for wallet account types.
+   */
+createAddress(params:
+⋮----
+/**
+   * List Addresses
+   *
+   * Lists addresses for an account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of addresses.
+   */
+getAddresses(params: {
+    account_id: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   * Show Address
+   *
+   * Get an single address for an account.
+   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
+   *
+   * !! An address can only be associated with one account. See Create Address to create new addresses.
+   */
+getAddress(params:
+⋮----
+/**
+   * List Address Transactions
+   *
+   * List transactions that have been sent to a specific address.
+   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
+   */
+getAddressTransactions(params: {
+    account_id: string;
+    addressId: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Transactions Endpoints
+   *
+   */
+⋮----
+/**
+   * Send Money
+   *
+   * Send funds to a network address for any Coinbase supported asset, or email address of the recipient.
+   * No transaction fees are required for off-blockchain cryptocurrency transactions.
+   *
+   * TRAVEL RULE DATA GUIDE: https://docs.cdp.coinbase.com/coinbase-app/docs/coinbase-app-travel-rule
+   */
+sendMoney(
+    params: CBAppSendMoneyRequest,
+): Promise<
+⋮----
+/**
+   * Transfer Money
+   *
+   * Transfer any Coinbase supported digital asset between two of a single user's accounts.
+   * Accounts must support the same currency for transfers to be successful.
+   */
+transferMoney(
+    params: CBAppTransferMoneyRequest,
+): Promise<
+⋮----
+/**
+   * List Transactions
+   *
+   * Lists the transactions of an account by account ID.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
+   */
+getTransactions(params: {
+    account_id: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   * Show Transaction
+   *
+   * Get a single transaction for an account.
+   */
+getTransaction(params: {
+    account_id: string;
+    transactionId: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Deposits Endpoints
+   *
+   */
+⋮----
+/**
+   * Deposit Funds
+   *
+   * Deposits user-defined amount of funds to a fiat account.
+   */
+depositFunds(params: CBAppDepositFundsRequest): Promise<CBAppTransfer>
+⋮----
+/**
+   * Commit Deposit
+   *
+   * Completes a deposit that is created in commit: false state.
+   */
+commitDeposit(params: {
+    account_id: string;
+    deposit_id: string;
+}): Promise<CBAppTransfer>
+⋮----
+/**
+   * List Deposits
+   *
+   * Lists fiat deposits for an account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of deposits.
+   */
+getDeposits(params:
+⋮----
+/**
+   * Show Deposit
+   *
+   * Get one deposit by deposit Id.
+   */
+getDeposit(params:
+⋮----
+/**
+   *
+   * Withdrawals Endpoints
+   *
+   */
+⋮----
+/**
+   * Withdraw Funds
+   *
+   * Withdraws a user-defined amount of funds from a fiat account.
+   */
+withdrawFunds(params: CBAppWithdrawFundsRequest): Promise<CBAppTransfer>
+⋮----
+/**
+   * Commit Withdrawal
+   *
+   * Completes a withdrawal that is created in commit: false state.
+   */
+commitWithdrawal(params: {
+    account_id: string;
+    withdrawal_id: string;
+}): Promise<CBAppTransfer>
+⋮----
+/**
+   * List Withdrawals
+   *
+   * Lists withdrawals for an account.
+   *
+   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
+   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of withdrawals.
+   */
+getWithdrawals(params: {
+    account_id: string;
+    paginationURL?: string;
+}): Promise<
+⋮----
+/**
+   * Show Withdrawal
+   *
+   * Get a single withdrawal.
+   */
+getWithdrawal(params: {
+    account_id: string;
+    withdrawal_id: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Subscriptions Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Coinbase One Subscription
+   *
+   * Returns a user's Coinbase One subscription status, tier, and current period end.
+   * Requires OAuth2 scope: wallet:subscription:read
+   */
+getCoinbaseOneSubscription(): Promise<
+⋮----
+/**
+   *
+   * DATA - Currencies Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Fiat Currencies
+   *
+   * Lists known fiat currencies. Currency codes conform to the ISO 4217 standard where possible.
+   * Currencies with no representation in ISO 4217 may use a custom code.
+   */
+getFiatCurrencies(): Promise<
+⋮----
+/**
+   * Get Cryptocurrencies
+   *
+   * Lists known cryptocurrencies.
+   */
+getCryptocurrencies(): Promise<CBAppCryptocurrency[]>
+⋮----
+/**
+   *
+   * DATA- Exchange rates Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Exchange Rates
+   *
+   * Get current exchange rates. Default base currency is USD but it can be defined as any supported currency.
+   * Returned rates will define the exchange rate for one unit of the base currency.
+   */
+getExchangeRates(params?:
+⋮----
+/**
+   *
+   * DATA - Prices Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Buy Price
+   *
+   * Get the total price to buy one bitcoin or ether.
+   * This endpoint doesn't require authentication.
+   */
+getBuyPrice(params:
+⋮----
+/**
+   * Get Sell Price
+   *
+   * Get the total price to sell one bitcoin or ether.
+   * This endpoint doesn't require authentication.
+   */
+getSellPrice(params:
+⋮----
+/**
+   * Get Spot Price
+   *
+   * Get the current market price for bitcoin. This is usually somewhere in between the buy and sell price.
+   * This endpoint doesn't require authentication.
+   */
+getSpotPrice(params:
+⋮----
+/**
+   *
+   * DATA - Time Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Current Time
+   *
+   * Get the API server time.
+   * This endpoint doesn't require authentication.
+   */
+getCurrentTime(): Promise<
+
+================
+File: src/CBCommerceClient.ts
+================
+import { AxiosRequestConfig } from 'axios';
+⋮----
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import {
+  REST_CLIENT_TYPE_ENUM,
+  RestClientOptions,
+  RestClientType,
+} from './lib/requestUtils.js';
+⋮----
+/**
+ * REST client for Coinbase Prime API:
+ * https://docs.cdp.coinbase.com/commerce-onchain/docs/welcome
+ */
+export class CBCommerceClient extends BaseRestClient
+⋮----
+constructor(
+    restClientOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {},
+)
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * Charges Endpoints
+   *
+   */
+⋮----
+/**
+   * Creates a Charge
+   *
+   * Creates a charge.
+   */
+createCharge(params: {
+    buyer_locale?: string;
+    cancel_url?: string;
+    checkout_id?: string;
+    local_price: {
+      amount: string;
+      currency: string;
+    };
+    metadata?: {
+      custom_field?: string;
+      custom_field_two?: string;
+    };
+    pricing_type: string;
+    redirect_url?: string;
+}): Promise<any>
+⋮----
+/**
+   * Returns All Charges
+   *
+   * Returns all charges.
+   */
+getAllCharges(): Promise<any>
+⋮----
+/**
+   * Returns the Charge with the Order Code
+   *
+   * Returns the charge with the order code.
+   */
+getCharge(params:
+⋮----
+/**
+   *
+   * Checkouts Endpoints
+   *
+   */
+⋮----
+/**
+   * Creates a New Checkout
+   *
+   * Creates a new checkout.
+   */
+createCheckout(params: {
+    buyer_locale?: string;
+    total_price: {
+      amount: string;
+      currency: string;
+    };
+    metadata?: {
+      custom_field?: string;
+      custom_field_two?: string;
+    };
+    pricing_type: string;
+    requested_info?: string[];
+}): Promise<any>
+⋮----
+/**
+   * Returns All Checkout Sessions
+   *
+   * Returns all checkout sessions.
+   */
+getAllCheckouts(): Promise<any>
+⋮----
+/**
+   * Returns a Specific Checkout Session
+   *
+   * Returns a specific checkout session.
+   */
+getCheckout(params:
+⋮----
+/**
+   *
+   * Events Endpoints
+   *
+   */
+⋮----
+/**
+   * List Events
+   *
+   * Lists all events.
+   */
+listEvents(headers:
+⋮----
+/**
+   * Show an Event
+   *
+   * Retrieves the details of an event. Supply the unique identifier of the event, which you might have received in a webhook.
+   */
+showEvent(
+    params: { event_id: string },
+    headers: { 'X-CC-Version': string },
+): Promise<any>
+
+================
+File: src/CBInternationalClient.ts
+================
+import { AxiosRequestConfig } from 'axios';
+⋮----
+import { BaseRestClient } from './lib/BaseRestClient.js';
+import {
+  REST_CLIENT_TYPE_ENUM,
+  RestClientOptions,
+  RestClientType,
+} from './lib/requestUtils.js';
+import {
+  CancelINTXOrdersRequest,
+  GetINTXAggregatedCandlesData,
+  GetINTXDailyTradingVolumes,
+  GetINTXFillsByPortfoliosRequest,
+  GetINTXIndexCandlesRequest,
+  GetINTXIndexCompositionHistory,
+  GetINTXMatchingTransfersRequest,
+  GetINTXOpenOrdersRequest,
+  GetINTXPortfolioFillsRequest,
+  INTXWithdrawToCounterpartyIdRequest,
+  INTXWithdrawToCryptoAddressRequest,
+  SubmitINTXOrderRequest,
+  TransferINTXFundsBetweenPortfoliosRequest,
+  TransferINTXPositionsBetweenPortfoliosRequest,
+  UpdateINTXOpenOrderRequest,
+  UpdateINTXPortfolioParametersRequest,
+} from './types/request/coinbase-international.js';
+⋮----
+/**
+ * REST client for Coinbase's Institutional International Exchange API:
+ * https://docs.cdp.coinbase.com/intx/docs/welcome
+ */
+export class CBInternationalClient extends BaseRestClient
+⋮----
+constructor(
+    restClientOptions: RestClientOptions = {},
+    requestOptions: AxiosRequestConfig = {},
+)
+⋮----
+getClientType(): RestClientType
+⋮----
+/**
+   *
+   * Assets Endpoints
+   *
+   */
+⋮----
+/**
+   * List assets
+   *
+   * Returns a list of all supported assets.
+   */
+getAssets(): Promise<any>
+⋮----
+/**
+   * Get asset details
+   *
+   * Retrieves information for a specific asset.
+   */
+getAssetDetails(params:
+⋮----
+/**
+   * Get supported networks per asset
+   *
+   * Returns a list of supported networks and network information for a specific asset.
+   */
+getSupportedNetworksPerAsset(params:
+⋮----
+/**
+   *
+   * Index Endpoints
+   *
+   */
+⋮----
+/**
+   * Get index composition
+   *
+   * Retrieves the latest index composition (metadata) with an ordered set of constituents.
+   */
+getIndexComposition(params:
+⋮----
+/**
+   * Get index composition history
+   *
+   * Retrieves a history of index composition records in a descending time order.
+   * The results are an array of index composition data recorded at different "timestamps".
+   */
+getIndexCompositionHistory(
+    params: GetINTXIndexCompositionHistory,
+): Promise<any>
+⋮----
+/**
+   * Get index price
+   *
+   * Retrieves the latest index price.
+   */
+getIndexPrice(params:
+⋮----
+/**
+   * Get index candles
+   *
+   * Retrieves the historical daily index prices in time descending order.
+   * The daily values are represented as aggregated entries for the day in typical OHLC format.
+   */
+getIndexCandles(params: GetINTXIndexCandlesRequest): Promise<any>
+⋮----
+/**
+   *
+   * Instruments Endpoints
+   *
+   */
+⋮----
+/**
+   * List instruments
+   *
+   * Returns all of the instruments available for trading.
+   */
+getInstruments(): Promise<any>
+⋮----
+/**
+   * Get instrument details
+   *
+   * Retrieves market information for a specific instrument.
+   */
+getInstrumentDetails(params:
+⋮----
+/**
+   * Get quote per instrument
+   *
+   * Retrieves the current quote for a specific instrument.
+   */
+getQuotePerInstrument(params:
+⋮----
+/**
+   * Get daily trading volumes
+   *
+   * Retrieves the trading volumes for each instrument separated by day.
+   */
+getDailyTradingVolumes(params: GetINTXDailyTradingVolumes): Promise<any>
+⋮----
+/**
+   * Get aggregated candles data per instrument
+   *
+   * Retrieves a list of aggregated candles data for a given instrument, granularity, and time range.
+   */
+getAggregatedCandlesData(params: GetINTXAggregatedCandlesData): Promise<any>
+⋮----
+/**
+   * Get historical funding rates
+   *
+   * Retrieves the historical funding rates for a specific instrument.
+   */
+getHistoricalFundingRates(params: {
+    instrument: string;
+    result_limit?: number;
+    result_offset?: number;
+}): Promise<any>
+⋮----
+/**
+   *
+   * Position Offsets Endpoints
+   *
+   */
+⋮----
+/**
+   * List position offsets
+   *
+   * Returns all active position offsets.
+   */
+getPositionOffsets(): Promise<any>
+⋮----
+/**
+   *
+   * Orders Endpoints
+   *
+   */
+⋮----
+/**
+   * Create order
+   *
+   * Creates a new order.
+   */
+submitOrder(params: SubmitINTXOrderRequest): Promise<any>
+⋮----
+/**
+   * List open orders
+   *
+   * Returns a list of active orders resting on the order book matching the requested criteria.
+   * Does not return any rejected, cancelled, or fully filled orders as they are not active.
+   */
+getOpenOrders(params?: GetINTXOpenOrdersRequest): Promise<any>
+⋮----
+/**
+   * Cancel orders
+   *
+   * Cancels all orders matching the requested criteria.
+   */
+cancelOrders(params: CancelINTXOrdersRequest): Promise<any>
+⋮----
+/**
+   * Modify open order
+   *
+   * Modifies an open order.
+   */
+updateOpenOrder(params: UpdateINTXOpenOrderRequest): Promise<any>
+⋮----
+/**
+   * Get order details
+   *
+   * Retrieves a single order. The order retrieved can be either active or inactive.
+   */
+getOrderDetails(params:
+⋮----
+/**
+   * Cancel order
+   *
+   * Cancels a single open order.
+   */
+cancelOrder(params:
+⋮----
+/**
+   *
+   * Portfolios Endpoints
+   *
+   */
+⋮----
+/**
+   * List all user portfolios
+   *
+   * Returns all of the user's portfolios.
+   */
+getUserPortfolios(): Promise<any>
+⋮----
+/**
+   * Create portfolio
+   *
+   * Create a new portfolio. Request will fail if no name is provided or if user already has max number of portfolios. Max number of portfolios is 20.
+   */
+createPortfolio(params:
+⋮----
+/**
+   * Patch portfolio
+   *
+   * Update parameters for existing portfolio.
+   */
+updatePortfolioParameters(
+    params: UpdateINTXPortfolioParametersRequest,
+): Promise<any>
+⋮----
+/**
+   * Get user portfolio
+   *
+   * Returns the user's specified portfolio.
+   */
+getUserPortfolio(params:
+⋮----
+/**
+   * Update portfolio
+   *
+   * Update existing user portfolio.
+   */
+updatePortfolio(params:
+⋮----
+/**
+   * Get portfolio details
+   *
+   * Retrieves the summary, positions, and balances of a portfolio.
+   */
+getPortfolioDetails(params:
+⋮----
+/**
+   * Get portfolio summary
+   *
+   * Retrieves the high level overview of a portfolio.
+   */
+getPortfolioSummary(params:
+⋮----
+/**
+   * List portfolio balances
+   *
+   * Returns all of the balances for a given portfolio.
+   */
+getPortfolioBalances(params:
+⋮----
+/**
+   * Get balance for portfolio/asset
+   *
+   * Retrieves the balance for a given portfolio and asset.
+   */
+getBalanceForPortfolioAsset(params: {
+    portfolio: string;
+    asset: string;
+}): Promise<any>
+⋮----
+/**
+   * List active loans for the portfolio
+   *
+   * Retrieves all loan info for a given portfolio.
+   */
+getActiveLoansForPortfolio(params:
+⋮----
+/**
+   * Get loan info for portfolio/asset
+   *
+   * Retrieves the loan info for a given portfolio and asset.
+   */
+getLoanInfoForPortfolioAsset(params: {
+    portfolio: string;
+    asset: string;
+}): Promise<any>
+⋮----
+/**
+   * Acquire/repay loan
+   *
+   * Acquire or repay loan for a given portfolio and asset.
+   */
+acquireOrRepayLoan(params: {
+    portfolio: string;
+    asset: string;
+    amount: number;
+    action: 'ACQUIRE' | 'REPAY';
+}): Promise<any>
+⋮----
+/**
+   * Preview loan update
+   *
+   * Preview acquire or repay loan for a given portfolio and asset.
+   */
+previewLoanUpdate(params: {
+    portfolio: string;
+    asset: string;
+    action: 'ACQUIRE' | 'REPAY';
+    amount: string;
+}): Promise<any>
+⋮----
+/**
+   * View max loan availability
+   *
+   * View the maximum amount of loan that could be acquired now for a given portfolio and asset.
+   */
+getMaxLoanAvailability(params: {
+    portfolio: string;
+    asset: string;
+}): Promise<any>
+⋮----
+/**
+   * List portfolio positions
+   *
+   * Returns all of the positions for a given portfolio.
+   */
+getPortfolioPositions(params:
+⋮----
+/**
+   * Get position for portfolio/instrument
+   *
+   * Retrieves the position for a given portfolio and symbol.
+   */
+getPositionForPortfolioInstrument(params: {
+    portfolio: string;
+    instrument: string;
+}): Promise<any>
+⋮----
+/**
+   * Get total open position limit
+   *
+   * Retrieves the total open position limit across instruments for a given portfolio.
+   */
+getTotalOpenPositionLimit(params:
+⋮----
+/**
+   * List open position limits for all instruments
+   *
+   * Retrieves position limits for all positions a given portfolio currently has or has opened in the past.
+   */
+getOpenPositionLimitsForAllInstruments(params: {
+    portfolio: string;
+}): Promise<any>
+⋮----
+/**
+   * Get open position limits for portfolio instrument
+   *
+   * Retrieves the position limits for a given portfolio and symbol.
+   */
+getOpenPositionLimitsForInstrument(params: {
+    portfolio: string;
+    instrument: string;
+}): Promise<any>
+⋮----
+/**
+   * List fills by portfolios
+   *
+   * Returns fills for specified portfolios or fills for all portfolios if none are provided.
+   */
+getFillsByPortfolios(params?: GetINTXFillsByPortfoliosRequest): Promise<any>
+⋮----
+/**
+   * List portfolio fills
+   *
+   * Returns all of the fills for a given portfolio.
+   */
+getPortfolioFills(params: GetINTXPortfolioFillsRequest): Promise<any>
+⋮----
+/**
+   * Enable/Disable portfolio cross collateral
+   *
+   * Enable or disable the cross collateral feature for the portfolio, which allows the portfolio to use non-USDC assets as collateral for margin trading.
+   */
+setCrossCollateral(params: {
+    portfolio: string;
+    enabled: boolean;
+}): Promise<any>
+⋮----
+/**
+   * Enable/Disable portfolio auto margin mode
+   *
+   * Enable or disable the auto margin feature, which lets the portfolio automatically
+   * post margin amounts required to exceed the high leverage position restrictions.
+   */
+setAutoMargin(params:
+⋮----
+/**
+   * Set portfolio margin override
+   *
+   * Specify the margin override value for a portfolio to either increase notional requirements or opt-in to higher leverage.
+   */
+setPortfolioMarginOverride(params: {
+    portfolio_id: string;
+    margin_override: string;
+}): Promise<any>
+⋮----
+/**
+   * Get fund transfer limit between portfolios
+   *
+   * Retrieves the maximum amount that can be transferred between portfolios for a specific asset.
+   * This applies to transfers between portfolios of the same beneficial owner.
+   */
+getFundTransferLimit(params: {
+    portfolio: string;
+    asset: string;
+}): Promise<any>
+⋮----
+/**
+   * Transfer funds between portfolios
+   *
+   * Transfer assets from one portfolio to another.
+   */
+transferFundsBetweenPortfolios(
+    params: TransferINTXFundsBetweenPortfoliosRequest,
+): Promise<any>
+⋮----
+/**
+   * Transfer positions between portfolios
+   *
+   * Transfer an existing position from one portfolio to another. The position transfer must fulfill the same portfolio-level margin requirements as submitting a new order on the opposite side for the sender's portfolio and a new order on the same side for the recipient's portfolio.
+   * Additionally, organization-level requirements must be satisfied when evaluating the outcome of the position transfer.
+   */
+transferPositionsBetweenPortfolios(
+    params: TransferINTXPositionsBetweenPortfoliosRequest,
+): Promise<any>
+⋮----
+/**
+   * List portfolio fee rates
+   *
+   * Retrieves the Perpetual Future and Spot fee rate tiers for the user.
+   */
+getPortfolioFeeRates(): Promise<any>
+/**
+   *
+   * Rankings Endpoints
+   *
+   */
+⋮----
+/**
+   * Get your rankings
+   *
+   * Retrieve your volume rankings for maker, taker, and total volume.
+   */
+getRankings(params: {
+    instrument_type: string;
+    period?: string;
+    instruments?: string;
+}): Promise<any>
+⋮----
+/**
+   *
+   * Transfers Endpoints
+   *
+   */
+⋮----
+/**
+   * List matching transfers
+   *
+   * List matching transfers.
+   */
+getMatchingTransfers(params?: GetINTXMatchingTransfersRequest): Promise<any>
+⋮----
+/**
+   * Get transfer
+   *
+   * Get transfer.
+   */
+getTransfer(params:
+⋮----
+/**
+   * Withdraw to crypto address
+   *
+   * Withdraw to crypto address.
+   */
+withdrawToCryptoAddress(
+    params: INTXWithdrawToCryptoAddressRequest,
+): Promise<any>
+⋮----
+/**
+   * Create crypto address
+   *
+   * Create crypto address.
+   */
+createCryptoAddress(params: {
+    portfolio: string;
+    asset: string;
+    network_arn_id: string;
+}): Promise<any>
+⋮----
+/**
+   * Create counterparty Id
+   *
+   * Create counterparty Id.
+   */
+createCounterpartyId(params:
+⋮----
+/**
+   * Validate counterparty Id
+   *
+   * Validate counterparty Id.
+   */
+validateCounterpartyId(params:
+⋮----
+/**
+   * Get counterparty withdrawal limit
+   *
+   * Retrieves the maximum amount that can be withdrawn to a counterparty within the Coinbase transfer network
+   * for a specific portfolio and asset.
+   */
+getCounterpartyWithdrawalLimit(params: {
+    portfolio: string;
+    asset: string;
+}): Promise<any>
+⋮----
+/**
+   * Withdraw to counterparty Id
+   *
+   * Withdraw to counterparty Id.
+   */
+withdrawToCounterpartyId(
+    params: INTXWithdrawToCounterpartyIdRequest,
+): Promise<any>
+/**
+   *
+   * Fee Rates Endpoints
+   *
+   */
+⋮----
+/**
+   * List fee rate tiers
+   *
+   * Return all the fee rate tiers.
+   */
+getFeeRateTiers(): Promise<any>
+
+================
+File: src/index.ts
+================
+
+
+================
+File: src/WebsocketClient.ts
+================
+import { BaseWebsocketClient, EmittableEvent } from './lib/BaseWSClient.js';
+import { signWSJWT } from './lib/jwtNode.js';
+import { neverGuard } from './lib/misc-util.js';
+import {
+  isCBAdvancedTradeErrorEvent,
+  isCBAdvancedTradeWSEvent,
+  isCBExchangeWSEvent,
+  isCBExchangeWSRequestOperation,
+  isCBINTXWSRequestOperation,
+  isCBPrimeWSRequestOperation,
+} from './lib/websocket/typeGuards.js';
+import {
+  getCBExchangeWSSign,
+  getCBInternationalWSSign,
+  getCBPrimeWSSign,
+  getMergedCBExchangeWSRequestOperations,
+  MessageEventLike,
+  WS_KEY_MAP,
+  WS_URL_MAP,
+  WsKey,
+  WsTopicRequest,
+} from './lib/websocket/websocket-util.js';
+import { WSConnectedResult } from './lib/websocket/WsStore.types.js';
+import { WsMarket } from './types/websockets/client.js';
+import {
+  WsAdvTradeRequestOperation,
+  WsExchangeAuthenticatedRequestOperation,
+  WsExchangeRequestOperation,
+  WsInternationalAuthenticatedRequestOperation,
+  WsInternationalRequestOperation,
+  WsOperation,
+  WsPrimeAuthenticatedRequestOperation,
+  WsPrimeRequestOperation,
+} from './types/websockets/requests.js';
+import {
+  WsAPITopicRequestParamMap,
+  WsAPITopicResponseMap,
+  WsAPIWsKeyTopicMap,
+} from './types/websockets/wsAPI.js';
+⋮----
+/**
+ * Any WS keys in this list will trigger automatic auth as required, if credentials are available
+ */
+⋮----
+// Account data (fills), requires auth.
+⋮----
+// Coinbase Direct Market Data has direct access to Coinbase Exchange servers and requires auth.
+⋮----
+// The INTX feed always requires auth.
+⋮----
+// The Prime feed always requires auth.
+⋮----
+/**
+ * Any WS keys in this list will ALWAYS skip the authentication process, even if credentials are available
+ */
+⋮----
+/**
+ * WS topics are always a string for this exchange. Some exchanges use complex objects.
+ */
+type WsTopic = string;
+⋮----
+export class WebsocketClient extends BaseWebsocketClient<WsKey>
+⋮----
+/**
+   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
+   */
+public connectAll(): Promise<(WSConnectedResult | undefined)[]>
+⋮----
+/**
+   * Request subscription to one or more topics. Pass topics as either an array of strings, or array of objects (if the topic has parameters).
+   * Objects should be formatted as {topic: string, params: object}.
+   *
+   * - Subscriptions are automatically routed to the correct websocket connection.
+   * - Authentication/connection is automatic.
+   * - Resubscribe after network issues is automatic.
+   *
+   * Call `unsubscribe(topics)` to remove topics
+   */
+public subscribe(
+    requests:
+      | (WsTopicRequest<WsTopic> | WsTopic)
+      | (WsTopicRequest<WsTopic> | WsTopic)[],
+    wsKey: WsKey,
+)
+⋮----
+/**
+   * Unsubscribe from one or more topics. Similar to subscribe() but in reverse.
+   *
+   * - Requests are automatically routed to the correct websocket connection.
+   * - These topics will be removed from the topic cache, so they won't be subscribed to again.
+   */
+public unsubscribe(
+    requests:
+      | (WsTopicRequest<WsTopic> | WsTopic)
+      | (WsTopicRequest<WsTopic> | WsTopic)[],
+    wsKey: WsKey,
+)
+⋮----
+/**
+   * Not supported by this exchange, do not use
+   */
+⋮----
+// This overload allows the caller to omit the 3rd param, if it isn't required (e.g. for the login call)
+async sendWSAPIRequest<
+    TWSKey extends keyof WsAPIWsKeyTopicMap,
+    TWSChannel extends WsAPIWsKeyTopicMap[TWSKey] = WsAPIWsKeyTopicMap[TWSKey],
+    TWSParams extends
+      WsAPITopicRequestParamMap[TWSChannel] = WsAPITopicRequestParamMap[TWSChannel],
+    TWSAPIResponse extends
+      | WsAPITopicResponseMap[TWSChannel]
+      | object = WsAPITopicResponseMap[TWSChannel],
+  >(
+    wsKey: TWSKey,
+    channel: TWSChannel,
+    ...params: TWSParams extends undefined ? [] : [TWSParams]
+  ): Promise<TWSAPIResponse>;
+⋮----
+async sendWSAPIRequest<
+    TWSKey extends keyof WsAPIWsKeyTopicMap = keyof WsAPIWsKeyTopicMap,
+    TWSChannel extends WsAPIWsKeyTopicMap[TWSKey] = WsAPIWsKeyTopicMap[TWSKey],
+    TWSParams extends
+      WsAPITopicRequestParamMap[TWSChannel] = WsAPITopicRequestParamMap[TWSChannel],
+  >(
+    wsKey: TWSKey,
+    channel: TWSChannel,
+    params?: TWSParams,
+): Promise<undefined>
+⋮----
+/**
+   *
+   * Internal methods
+   *
+   */
+⋮----
+/**
+   * Return a websocket URL, which is connected to as-is.
+   * If a token or anything else is needed in the URL, this is a good place to add it.
+   */
+protected async getWsUrl(wsKey: WsKey): Promise<string>
+⋮----
+protected sendPingEvent(wsKey: WsKey)
+⋮----
+protected sendPongEvent(wsKey: WsKey)
+⋮----
+// Send a protocol layer pong
+⋮----
+protected isWsPing(msg: any): boolean
+⋮----
+protected isWsPong(msg: any): boolean
+⋮----
+// this.logger.info(`Not a pong: `, msg);
+⋮----
+protected resolveEmittableEvents(
+    wsKey: WsKey,
+    event: MessageEventLike,
+): EmittableEvent[]
+⋮----
+// E.g. {"type":"error","message":"rate limit exceeded","wsKey":"advTradeMarketData"}
+⋮----
+// Parse Advanced Trade WS events (update & response)
+⋮----
+// These are request/reply pattern events (e.g. after subscribing to topics or authenticating)
+⋮----
+// Generic data for a channel
+⋮----
+// Parse CB Exchange WS events
+⋮----
+// Generic data for a channel
+⋮----
+/**
+   * Determines if a topic is for a private channel, using a hardcoded list of strings
+   */
+protected isPrivateTopicRequest(
+    request: WsTopicRequest<string>,
+    wsKey: WsKey,
+): boolean
+⋮----
+protected getWsKeyForMarket(market: WsMarket, isPrivate: boolean): WsKey
+⋮----
+protected getWsMarketForWsKey(wsKey: WsKey): WsMarket
+⋮----
+protected getPrivateWSKeys(): WsKey[]
+⋮----
+/** Force subscription requests to be sent in smaller batches, if a number is returned */
+protected getMaxTopicsPerSubscribeEvent(wsKey: WsKey): number | null
+⋮----
+// Technically, INTX supports request batching but not with nested parameters, so we'll send one at a time
+⋮----
+// Exchange supports request batching, no known limit to max topics per request
+⋮----
+/**
+   * Map one or more topics into fully prepared "subscribe request" events (already stringified and ready to send)
+   */
+protected async getWsOperationEventsForTopics(
+    topicRequests: WsTopicRequest<string>[],
+    wsKey: WsKey,
+    operation: WsOperation,
+): Promise<string[]>
+⋮----
+/**
+     * Operations need to be structured in a way that this exchange understands.
+     * Parse the internal format into the format expected by the exchange. One request per operation.
+     */
+⋮----
+// In case there's ever more operation types than "subscribe" and "unsubscribe"
+⋮----
+// As of Sep 2024, parameters (such as product_id[]) cannot be nested with the channels array
+⋮----
+// This merges parametrs (such as product_id[]) into the top level request object
+⋮----
+/**
+     * - Merge commands into one if the exchange supports batch requests,
+     * - Apply auth/sign, if needed,
+     * - Apply any final formatting to return a string array, ready to be sent upstream.
+     */
+⋮----
+// Events that are ready to send (usually stringified JSON)
+// ADV trade only supports sending one at a time, so we don't try to merge them
+// These are already signed, if needed.
+⋮----
+/**
+           * No batching is supported for this product group, so we can already
+           * handle sign here and return it as is
+           */
+⋮----
+// Don't expect this to ever happen, but just to please typescript...
+⋮----
+// We're under the max topics per request limit.
+// Send operation requests as one merged request
+⋮----
+// We're over the max topics per request limit. Break into batches.
+⋮----
+// Don't expect this to ever happen, but just to please typescript...
+⋮----
+// We're over the max topics per request limit. Break into batches.
+⋮----
+// throw new Error(
+//   'CB INTX is not fully implemented yet - awaiting test environment... if you need this, please get in touch.',
+// );
+⋮----
+// Don't expect this to ever happen, but just to please typescript...
+⋮----
+// throw new Error(
+//   'CB Prime is not fully implemented yet - awaiting test environment... if you need this, please get in touch.',
+// );
+⋮----
+// throw new Error(`Not implemented for "${wsKey}" yet`);
+⋮----
+/**
+   * Events are signed per-request, so this function isn't needed for Coinbase.
+   */
+protected async getWsAuthRequestEvent(wsKey: WsKey): Promise<object>
+
+================
+File: .eslintrc.cjs
+================
+// 'no-unused-vars': ['warn'],
+
+================
+File: .prettierrc
+================
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all"
+}
+
+================
+File: index.js
+================
+
+
+================
+File: jest.config.ts
+================
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+⋮----
+import type { Config } from 'jest';
+⋮----
+// All imported modules in your tests should be mocked automatically
+// automock: false,
+⋮----
+// Stop running tests after `n` failures
+// bail: 0,
+bail: false, // enable to stop test when an error occur,
+⋮----
+// The directory where Jest should store its cached dependency information
+// cacheDirectory: "/private/var/folders/kf/2k3sz4px6c9cbyzj1h_b192h0000gn/T/jest_dx",
+⋮----
+// Automatically clear mock calls, instances, contexts and results before every test
+⋮----
+// Indicates whether the coverage information should be collected while executing the test
+⋮----
+// An array of glob patterns indicating a set of files for which coverage information should be collected
+⋮----
+// The directory where Jest should output its coverage files
+⋮----
+// An array of regexp pattern strings used to skip coverage collection
+// coveragePathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+⋮----
+// Indicates which provider should be used to instrument code for coverage
+⋮----
+// A list of reporter names that Jest uses when writing coverage reports
+// coverageReporters: [
+//   "json",
+//   "text",
+//   "lcov",
+//   "clover"
+// ],
+⋮----
+// An object that configures minimum threshold enforcement for coverage results
+// coverageThreshold: undefined,
+⋮----
+// A path to a custom dependency extractor
+// dependencyExtractor: undefined,
+⋮----
+// Make calling deprecated APIs throw helpful error messages
+// errorOnDeprecated: false,
+⋮----
+// The default configuration for fake timers
+// fakeTimers: {
+//   "enableGlobally": false
+// },
+⋮----
+// Force coverage collection from ignored files using an array of glob patterns
+// forceCoverageMatch: [],
+⋮----
+// A path to a module which exports an async function that is triggered once before all test suites
+// globalSetup: undefined,
+⋮----
+// A path to a module which exports an async function that is triggered once after all test suites
+// globalTeardown: undefined,
+⋮----
+// A set of global variables that need to be available in all test environments
+// globals: {},
+⋮----
+// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+// maxWorkers: "50%",
+⋮----
+// An array of directory names to be searched recursively up from the requiring module's location
+// moduleDirectories: [
+//   "node_modules"
+// ],
+⋮----
+// An array of file extensions your modules use
+⋮----
+// modulePaths: ['src'],
+⋮----
+// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
+// moduleNameMapper: {},
+⋮----
+// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+// modulePathIgnorePatterns: [],
+⋮----
+// Activates notifications for test results
+// notify: false,
+⋮----
+// An enum that specifies notification mode. Requires { notify: true }
+// notifyMode: "failure-change",
+⋮----
+// A preset that is used as a base for Jest's configuration
+// preset: undefined,
+⋮----
+// Run tests from one or more projects
+// projects: undefined,
+⋮----
+// Use this configuration option to add custom reporters to Jest
+// reporters: undefined,
+⋮----
+// Automatically reset mock state before every test
+// resetMocks: false,
+⋮----
+// Reset the module registry before running each individual test
+// resetModules: false,
+⋮----
+// A path to a custom resolver
+// resolver: undefined,
+⋮----
+// Automatically restore mock state and implementation before every test
+// restoreMocks: false,
+⋮----
+// The root directory that Jest should scan for tests and modules within
+// rootDir: undefined,
+⋮----
+// A list of paths to directories that Jest should use to search for files in
+// roots: [
+//   "<rootDir>"
+// ],
+⋮----
+// Allows you to use a custom runner instead of Jest's default test runner
+// runner: "jest-runner",
+⋮----
+// The paths to modules that run some code to configure or set up the testing environment before each test
+// setupFiles: [],
+⋮----
+// A list of paths to modules that run some code to configure or set up the testing framework before each test
+// setupFilesAfterEnv: [],
+⋮----
+// The number of seconds after which a test is considered as slow and reported as such in the results.
+// slowTestThreshold: 5,
+⋮----
+// A list of paths to snapshot serializer modules Jest should use for snapshot testing
+// snapshotSerializers: [],
+⋮----
+// The test environment that will be used for testing
+// testEnvironment: "jest-environment-node",
+⋮----
+// Options that will be passed to the testEnvironment
+// testEnvironmentOptions: {},
+⋮----
+// Adds a location field to test results
+// testLocationInResults: false,
+⋮----
+// The glob patterns Jest uses to detect test files
+⋮----
+// "**/__tests__/**/*.[jt]s?(x)",
+⋮----
+// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+// testPathIgnorePatterns: [
+//   "/node_modules/"
+// ],
+⋮----
+// The regexp pattern or array of patterns that Jest uses to detect test files
+// testRegex: [],
+⋮----
+// This option allows the use of a custom results processor
+// testResultsProcessor: undefined,
+⋮----
+// This option allows use of a custom test runner
+// testRunner: "jest-circus/runner",
+⋮----
+// A map from regular expressions to paths to transformers
+// transform: undefined,
+⋮----
+// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+// transformIgnorePatterns: [
+//   "/node_modules/",
+//   "\\.pnp\\.[^\\/]+$"
+// ],
+⋮----
+// Prevents import esm module error from v1 axios release, issue #5026
+⋮----
+// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+// unmockedModulePathPatterns: undefined,
+⋮----
+// Indicates whether each individual test should be reported during the run
+// verbose: undefined,
+verbose: true, // report individual test
+⋮----
+// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+// watchPathIgnorePatterns: [],
+⋮----
+// Whether to use watchman for file crawling
+// watchman: true,
+
+================
+File: postBuild.sh
+================
+#!/bin/bash
+#
+#   Add package.json files to cjs/mjs subtrees
+#
+
+cat >dist/cjs/package.json <<!EOF
+{
+    "type": "commonjs"
+}
+!EOF
+
+cat >dist/mjs/package.json <<!EOF
+{
+    "type": "module"
+}
+!EOF
+
+find src -name '*.d.ts' -exec cp {} dist/mjs \;
+find src -name '*.d.ts' -exec cp {} dist/cjs \;
+
+================
+File: tsconfig.cjs.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext"
+  },
+  "include": ["src/**/*.*"]
+}
+
+================
+File: tsconfig.esm.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/mjs",
+    "target": "esnext"
+  },
+  "include": ["src/**/*.*"]
+}
+
+================
+File: tsconfig.linting.json
+================
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/cjs",
+    "target": "esnext",
+    "rootDir": "../",
+    "allowJs": true
+  },
+  "include": [
+    "src/**/*.*",
+    "test/**/*.*",
+    "examples/**/*.*",
+    ".eslintrc.cjs",
+    "jest.config.ts"
+  ]
+}
+
+================
+File: examples/Institutional/CBExchange/Rest/cb-exchange-private.ts
+================
+import { CBExchangeClient } from '../../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// Initialize the client, you can pass in api keys here if you have them but they are not required for public endpoints
+⋮----
+//This is the passphrase you provided when creating this API key. NOT your account password.
+⋮----
+// Optional, connect to sandbox instead: https://public-sandbox.exchange.coinbase.com/apikeys
+// useSandbox: true,
+⋮----
+async function privateExchangeCalls()
+
+================
+File: examples/Institutional/CBExchange/Rest/cb-exchange-public.ts
+================
+import { CBExchangeClient } from '../../../../src/index.js';
+⋮----
+/**
+ * import { CBAdvancedTradeClient } from 'coinbase-api';
+ * const { CBAdvancedTradeClient } = require('coinbase-api');
+ */
+⋮----
+// Initialize the client, you can pass in api keys here if you have them but they are not required for public endpoints
+⋮----
+async function publicExchangeCalls()
+⋮----
+// Get all known currencies
+⋮----
+// Get a single currency by id
+⋮----
+// Get all known trading pairs
+⋮----
+// Get all product volume
+⋮----
+// Get all wrapped assets
+
+================
+File: examples/Institutional/CBExchange/WebSockets/privateWs.ts
+================
+import { WebsocketClient } from '../../../../src/index.js';
+⋮----
+/**
+ * import { WebsocketClient } from 'coinbase-api';
+ * const { WebsocketClient } = require('coinbase-api');
+ */
+⋮----
+async function start()
+⋮----
+//This is the passphrase you provided when creating this API key. NOT your account password.
+⋮----
+// Optional, connect to sandbox instead: https://public-sandbox.exchange.coinbase.com/apikeys
+// useSandbox: true,
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+/**
+     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
+     * - You can subscribe to topics one at a time or many one one request.
+     * - Topics can be sent as simple strings, if no parameters are required.
+     * - If parameters are required, pass them in the "payload" property - they will be merged into the subscription request automatically
+     * - Any subscribe requests on the "exchangeDirectMarketData" market are automatically authenticated with the available credentials
+     */
+⋮----
+/**
+     * Other examples for some of the authenticated Coinbase Exchange "direct market data" channels:
+     */
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#full-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#user-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#level2-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#balance-channel
+
+================
+File: examples/Institutional/CBExchange/WebSockets/publicWs.ts
+================
+import { WebsocketClient } from '../../../../src/index.js';
+⋮----
+/**
+ * import { WebsocketClient } from 'coinbase-api';
+ * const { WebsocketClient } = require('coinbase-api');
+ */
+⋮----
+async function start()
+⋮----
+/**
+   * All websockets are available via the unified WebsocketClient.
+   *
+   * Below are examples specific to websockets in this product group.
+   */
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+// throw new Error('res?');
+⋮----
+/**
+     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
+     *
+     * - You can subscribe to topics one at a time or many one one request.
+     * - Topics can be sent as simple strings, if no parameters are required.
+     * - Coinbase Market Data is the traditional feed which is available without authentication.
+     * - To use this feed, use 'exchangeMarketData' as the wsKey for each subscription command:
+     */
+// client.subscribe('status', 'exchangeMarketData');
+⋮----
+/**
+     * Or send a more structured object with parameters, e.g. if parameters are required
+     */
+// const tickerSubscribeRequest: WsTopicRequest = {
+//   topic: 'ticker',
+//   /**
+//    * Anything in the payload will be merged into the subscribe "request",
+//    * allowing you to send misc parameters supported by the exchange (such as `product_ids: string[]`)
+//    */
+//   payload: {
+//     product_ids: ['ETH-USD', 'ETH-EUR'],
+//   },
+// };
+// client.subscribe(tickerSubscribeRequest, 'exchangeMarketData');
+⋮----
+/**
+     * Subscribe to the "heartbeat" topic for a few symbols
+     */
+// client.subscribe(
+//   {
+//     topic: 'heartbeat',
+//     payload: {
+//       product_ids: ['ETH-USD', 'BTC-USD'],
+//     },
+//   },
+//   'exchangeMarketData',
+// );
+⋮----
+// client.subscribe(
+//   {
+//     topic: 'level2',
+//     payload: {
+//       product_ids: ['ETH-USD', 'BTC-USD'],
+//     },
+//   },
+//   'exchangeMarketData',
+// );
+⋮----
+// /**
+//  * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
+//  */
+// // client.subscribe([level2SubscribeRequest, anotherRequest, etc], 'advTradeMarketData');
+⋮----
+/**
+     * Other Coinbase Exchange public websocket topics:
+     */
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#heartbeat-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#status-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#auction-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#matches-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#rfq-matches-channel
+⋮----
+// Optional:
+// product_ids: ['ETH-USD', 'BTC-USD'],
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#ticker-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#ticker-batch-channel
+⋮----
+// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#level2-batch-channel
+
+================
+File: examples/Institutional/CBInternationalExchange/cb-intx-public.ts
+================
+import { CBInternationalClient } from '../../../src/index.js';
+⋮----
+/**
+ * import { CBInternationalClient } from 'coinbase-api';
+ * const { CBInternationalClient } = require('coinbase-api');
+ */
+⋮----
+// Initialize the client, you can pass in api keys here if you have them but they are not required for public endpoints
+⋮----
+async function publicInternationalCalls()
+⋮----
+// List assets
+⋮----
+// Get asset details
+⋮----
+// Get supported networks per asset
+⋮----
+// List instruments
+⋮----
+// Get instrument details
+⋮----
+// Get quote per instrument
+⋮----
+// Get daily trading volumes
+⋮----
+// Get aggregated candles data per instrument
+⋮----
+// Get historical funding rates
+⋮----
+// List position offsets
+
+================
+File: examples/Institutional/CBInternationalExchange/cb-intx-ws.ts
+================
+import { WebsocketClient, WsTopicRequest } from '../../../src/index.js';
+⋮----
+/**
+ * import { WebsocketClient, WsTopicRequest } from 'coinbase-api';
+ * const { WebsocketClient, WsTopicRequest } = require('coinbase-api');
+ */
+⋮----
+// logger,
+⋮----
+// Data received
+⋮----
+// Something happened, attempting to reconenct
+⋮----
+// Reconnect successful
+⋮----
+// Connection closed. If unexpected, expect reconnect -> reconnected.
+⋮----
+// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
+⋮----
+topic: 'LEVEL1', // ws topic
+/**
+   * Anything in the payload will be merged into the subscribe "request",
+   * allowing you to send misc parameters supported by the exchange (such as `product_ids: string[]`)
+   */
+
+================
+File: src/lib/websocket/WsStore.ts
+================
+import WebSocket from 'isomorphic-ws';
+⋮----
+import { DefaultLogger } from './logger.js';
+import {
+  DeferredPromise,
+  WSConnectedResult,
+  WsConnectionStateEnum,
+  WsStoredState,
+} from './WsStore.types.js';
+⋮----
+/**
+ * Simple comparison of two objects, recursive for nested objects
+ */
+export function isDeepObjectMatch(object1: unknown, object2: unknown): boolean
+⋮----
+type DeferredPromiseRef =
+  (typeof DEFERRED_PROMISE_REF)[keyof typeof DEFERRED_PROMISE_REF];
+⋮----
+export class WsStore<
+WsKey extends string,
+⋮----
+constructor(logger: typeof DefaultLogger)
+⋮----
+/** Get WS stored state for key, optionally create if missing */
+get(
+    key: WsKey,
+    createIfMissing?: true,
+  ): WsStoredState<TWSTopicSubscribeEventArgs>;
+⋮----
+get(
+    key: WsKey,
+    createIfMissing?: false,
+  ): WsStoredState<TWSTopicSubscribeEventArgs> | undefined;
+⋮----
+get(
+    key: WsKey,
+    createIfMissing?: boolean,
+): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
+⋮----
+getKeys(): WsKey[]
+⋮----
+create(key: WsKey): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
+⋮----
+delete(key: WsKey): void
+⋮----
+// TODO: should we allow this at all? Perhaps block this from happening...
+⋮----
+/* connection websocket */
+⋮----
+hasExistingActiveConnection(key: WsKey): boolean
+⋮----
+getWs(key: WsKey): WebSocket | undefined
+⋮----
+setWs(key: WsKey, wsConnection: WebSocket): WebSocket
+⋮----
+getDeferredPromise<TSuccessResult = any>(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+): DeferredPromise<TSuccessResult> | undefined
+⋮----
+createDeferredPromise<TSuccessResult = any>(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    throwIfExists: boolean,
+): DeferredPromise<TSuccessResult>
+⋮----
+// console.log('existing promise');
+⋮----
+// console.log('create promise');
+⋮----
+// TODO: Once stable, use Promise.withResolvers in future
+⋮----
+resolveDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    value: unknown,
+    removeAfter: boolean,
+): void
+⋮----
+rejectDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+    value: unknown,
+    removeAfter: boolean,
+): void
+⋮----
+removeDeferredPromise(
+    wsKey: WsKey,
+    promiseRef: string | DeferredPromiseRef,
+): void
+⋮----
+// Just in case it's pending
+⋮----
+rejectAllDeferredPromises(wsKey: WsKey, reason: string): void
+⋮----
+// Skip reserved keys, such as the connection promise
+⋮----
+/** Get promise designed to track a connection attempt in progress. Resolves once connected. */
+getConnectionInProgressPromise(
+    wsKey: WsKey,
+): DeferredPromise<WSConnectedResult> | undefined
+⋮----
+/**
+   * Create a deferred promise designed to track a connection attempt in progress.
+   *
+   * Will throw if existing promise is found.
+   */
+createConnectionInProgressPromise(
+    wsKey: WsKey,
+    throwIfExists: boolean,
+): DeferredPromise<WSConnectedResult>
+⋮----
+/** Remove promise designed to track a connection attempt in progress */
+removeConnectingInProgressPromise(wsKey: WsKey): void
+⋮----
+/* connection state */
+⋮----
+isWsOpen(key: WsKey): boolean
+⋮----
+getConnectionState(key: WsKey): WsConnectionStateEnum
+⋮----
+setConnectionState(key: WsKey, state: WsConnectionStateEnum)
+⋮----
+// console.log(new Date(), `setConnectionState(${key}, ${state})`);
+⋮----
+isConnectionState(key: WsKey, state: WsConnectionStateEnum): boolean
+⋮----
+/**
+   * Check if we're currently in the process of opening a connection for any reason. Safer than only checking "CONNECTING" as the state
+   * @param key
+   * @returns
+   */
+isConnectionAttemptInProgress(key: WsKey): boolean
+⋮----
+/* subscribed topics */
+⋮----
+getTopics(key: WsKey): Set<TWSTopicSubscribeEventArgs>
+⋮----
+getTopicsByKey(): Record<string, Set<TWSTopicSubscribeEventArgs>>
+⋮----
+// Since topics are objects we can't rely on the set to detect duplicates
+/**
+   * Find matching "topic" request from the store
+   * @param key
+   * @param topic
+   * @returns
+   */
+getMatchingTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// if (typeof topic === 'string') {
+//   return this.getMatchingTopic(key, { channel: topic });
+// }
+⋮----
+addTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// console.log(`wsStore.addTopic(${key}, ${topic})`);
+// Check for duplicate topic. If already tracked, don't store this one
+⋮----
+deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
+⋮----
+// Check if we're subscribed to a topic like this
 
 ================
 File: src/lib/requestUtils.ts
@@ -679,6 +4157,9 @@ import { CustomOrderIdProperty } from '../types/shared.types.js';
 ⋮----
 export type RestClientType =
   (typeof REST_CLIENT_TYPE_ENUM)[keyof typeof REST_CLIENT_TYPE_ENUM];
+⋮----
+// Static Advanced Trade sandbox (mocked accounts/orders). No matching engine / WebSocket sandbox.
+// https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox
 ⋮----
 export interface RestClientOptions {
   /**
@@ -737,12 +4218,14 @@ export interface RestClientOptions {
   /**
    * Connect to the sandbox for supported products
    *
+   * - Coinbase Advanced Trade: static REST sandbox (mocked accounts/orders, no matching engine):
+   *   https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox
    * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
    * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
    *
    * - Coinbase App: No sandbox available.
-   * - Coinbase Advanced Trade: No sandbox available.
    * - Coinbase Prime: No sandbox available.
+   * - Coinbase Commerce: No sandbox available.
    */
   useSandbox?: boolean;
 
@@ -815,12 +4298,14 @@ export interface RestClientOptions {
 /**
    * Connect to the sandbox for supported products
    *
+   * - Coinbase Advanced Trade: static REST sandbox (mocked accounts/orders, no matching engine):
+   *   https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox
    * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
    * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
    *
    * - Coinbase App: No sandbox available.
-   * - Coinbase Advanced Trade: No sandbox available.
    * - Coinbase Prime: No sandbox available.
+   * - Coinbase Commerce: No sandbox available.
    */
 ⋮----
 /**
@@ -882,47 +4367,6 @@ export function getRestBaseUrl(
  * @returns
  */
 export function getParamsFromURL(url: string):
-
-================
-File: src/lib/webCryptoAPI.ts
-================
-import { neverGuard } from './misc-util.js';
-⋮----
-function bufferToB64(buffer: ArrayBuffer): string
-⋮----
-function b64StringToBuffer(input: string): Uint8Array
-⋮----
-const binaryString = atob(input); // Decode base64 string
-⋮----
-// Convert binary string to a Uint8Array
-⋮----
-export type SignEncodeMethod = 'hex' | 'base64';
-export type SignAlgorithm = 'SHA-256' | 'SHA-512';
-⋮----
-/**
- * Similar to node crypto's `createHash()` function
- */
-export async function hashMessage(
-  message: string,
-  method: SignEncodeMethod,
-  algorithm: SignAlgorithm,
-): Promise<string>
-⋮----
-/**
- * Sign a message, with a secret, using the Web Crypto API
- */
-export async function signMessage(
-  message: string,
-  secret: string,
-  method: SignEncodeMethod,
-  algorithm: SignAlgorithm,
-  secretEncodeMethod: 'base64:web' | 'utf',
-): Promise<string>
-⋮----
-// case 'base64:node': {
-//   encodedSecret = Buffer.from(secret, 'base64');
-//   break;
-// }
 
 ================
 File: src/types/request/advanced-trade-client.ts
@@ -1175,7 +4619,7 @@ export interface GetAdvTradePublicMarketTradesRequest {
   end?: string;
 }
 ⋮----
-export interface EditAdvTradeOrderRequest {
+export interface UpdateAdvTradeOrderRequest {
   order_id: string;
   price?: string;
   size?: string;
@@ -1193,122 +4637,6 @@ export interface EditAdvTradeOrderRequest {
 /**
  *
  * Data API Endpoints
- *
- */
-
-================
-File: src/types/request/coinbase-app-client.ts
-================
-/**
- *
- * Account Endpoints
- *
- */
-⋮----
-/**
- *
- * Address Endpoints
- *
- */
-⋮----
-/**
- *
- * Transactions Endpoints
- *
- */
-⋮----
-export interface CBAppBeneficiaryAddress {
-  address1: string;
-  address2?: string;
-  address3?: string;
-  city?: string;
-  state?: string;
-  country?: string; // ISO 3166-1 alpha-2 country code
-  postal_code?: string;
-}
-⋮----
-country?: string; // ISO 3166-1 alpha-2 country code
-⋮----
-export interface CBAppTravelRuleData {
-  beneficiary_wallet_type: 'WALLET_TYPE_SELF_HOSTED' | 'WALLET_TYPE_EXCHANGE';
-  is_self: 'IS_SELF_FALSE' | 'IS_SELF_TRUE';
-  beneficiary_name: string;
-  beneficiary_address: CBAppBeneficiaryAddress;
-  beneficiary_financial_institution: string;
-  transfer_purpose: string;
-}
-⋮----
-export interface CBAppSendMoneyRequest {
-  account_id: string;
-  type: 'send';
-  to: string;
-  amount: string;
-  currency: string;
-  description?: string;
-  skip_notifications?: boolean;
-  idem?: string;
-  destination_tag?: string;
-  network?: string;
-  travel_rule_data?: CBAppTravelRuleData;
-}
-⋮----
-export interface CBAppTransferMoneyRequest {
-  account_id: string;
-  type: 'transfer';
-  to: string;
-  amount: string;
-  currency: string;
-  description?: string;
-}
-/**
- *
- * Deposits Endpoints
- *
- */
-⋮----
-export interface CBAppDepositFundsRequest {
-  account_id: string;
-  amount: string;
-  currency: string;
-  payment_method: string;
-  commit?: boolean;
-}
-⋮----
-/**
- *
- * Withdrawals Endpoints
- *
- */
-⋮----
-export interface CBAppWithdrawFundsRequest {
-  account_id: string;
-  amount: string;
-  currency: string;
-  payment_method: string;
-  commit?: boolean;
-}
-⋮----
-/**
- *
- * DATA - Currencies Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA- Exchange rates Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA - Prices Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA - Time Endpoints
  *
  */
 
@@ -2222,8 +5550,39 @@ export interface GetPrimeOrderFillsRequest {
 export interface GetPrimePortfolioProductsRequest {
   portfolio_id: string;
   cursor?: string;
+  /** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
   limit?: number;
   sort_direction?: 'DESC' | 'ASC';
+  /** If unset, returns all product types available for the portfolio (including FUTURE). */
+  product_type?: 'SPOT' | 'FUTURE' | 'OPTION';
+  /** Only applicable when product_type = FUTURE. */
+  contract_expiry_type?:
+    | 'CONTRACT_EXPIRY_TYPE_EXPIRING'
+    | 'CONTRACT_EXPIRY_TYPE_PERPETUAL';
+  /** Filter by expiry status for expiring futures. */
+  expiring_contract_status?:
+    | 'EXPIRING_CONTRACT_STATUS_UNEXPIRED'
+    | 'EXPIRING_CONTRACT_STATUS_EXPIRED'
+    | 'EXPIRING_CONTRACT_STATUS_ALL';
+}
+⋮----
+/** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
+⋮----
+/** If unset, returns all product types available for the portfolio (including FUTURE). */
+⋮----
+/** Only applicable when product_type = FUTURE. */
+⋮----
+/** Filter by expiry status for expiring futures. */
+⋮----
+/**
+ *
+ * Travel Rule Endpoints
+ *
+ */
+⋮----
+export interface GetPrimeTransactionTravelRuleDataRequest {
+  portfolio_id: string;
+  transaction_id: string;
 }
 ⋮----
 /**
@@ -3239,297 +6598,6 @@ export interface AdvTradeApiKeyPermissions {
 }
 
 ================
-File: src/types/response/coinbase-app-client.ts
-================
-export interface CBAppPagination {
-  ending_before?: string | null;
-  starting_after?: string | null;
-  limit?: number;
-  order?: string;
-  previous_uri: string | null;
-  next_uri: string | null;
-}
-⋮----
-/**
- *
- * Account Endpoints
- *
- */
-⋮----
-interface AccountCurrency {
-  address_regex: string;
-  asset_id: string;
-  code: string;
-  color: string;
-  exponent: number;
-  name: string;
-  slug: string;
-  sort_index: number;
-  type: string;
-}
-⋮----
-interface AccountBalance {
-  amount: string;
-  currency: string;
-}
-⋮----
-export interface CBAppAccount {
-  id: string;
-  name: string;
-  primary: boolean;
-  type: string;
-  currency: AccountCurrency;
-  balance: AccountBalance;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-  ready: boolean;
-}
-⋮----
-/**
- *
- * Address Endpoints
- *
- */
-⋮----
-export interface CBAppAddress {
-  id: string;
-  address: string;
-  name?: string;
-  network: string;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-}
-⋮----
-/**
- *
- * Transactions Endpoints
- *
- */
-⋮----
-interface TransactionAmount {
-  amount: string;
-  currency: string;
-}
-⋮----
-interface TransactionNetwork {
-  status: string;
-  name: string;
-  hash?: string;
-  transaction_fee?: TransactionAmount;
-  transaction_amount?: TransactionAmount;
-  network_name?: string;
-  status_description?: string | null;
-}
-⋮----
-interface TransactionFrom {
-  id: string;
-  resource: string;
-  resource_path?: string;
-}
-⋮----
-interface TransactionTo {
-  resource: string;
-  address?: string;
-  email?: string;
-  id?: string;
-  resource_path?: string;
-}
-⋮----
-interface TransactionDetails {
-  title: string;
-  subtitle: string;
-  header?: string;
-  health?: string;
-  subsidebar_label?: string | null;
-}
-⋮----
-interface AdvancedTradeFill {
-  fill_price: string;
-  product_id: string;
-  order_id: string;
-  commission: string;
-  order_side: 'BUY' | 'SELL';
-}
-⋮----
-export interface CBAppTransaction {
-  id: string;
-  type: string;
-  status: string;
-  amount: TransactionAmount;
-  native_amount: TransactionAmount;
-  description: string | null;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-  network?: TransactionNetwork;
-  from?: TransactionFrom;
-  to?: TransactionTo;
-  details?: TransactionDetails;
-  instant_exchange?: boolean;
-  advanced_trade_fill?: AdvancedTradeFill;
-  cancelable?: boolean;
-  idem?: string;
-}
-⋮----
-/**
- *
- * Deposits/Withdrawal Endpoints
- *
- */
-⋮----
-interface DepositWithdrawalPaymentMethod {
-  id: string;
-  resource: string;
-  resource_path: string;
-}
-⋮----
-interface DepositWithdrawalTransaction {
-  id: string;
-  resource: string;
-  resource_path: string;
-}
-⋮----
-interface DepositWithdrawalAmountCurrency {
-  amount: string;
-  currency: string;
-}
-⋮----
-export interface CBAppDepositWithdrawal {
-  id: string;
-  status: string;
-  payment_method: DepositWithdrawalPaymentMethod;
-  transaction: DepositWithdrawalTransaction;
-  amount: DepositWithdrawalAmountCurrency;
-  subtotal: DepositWithdrawalAmountCurrency;
-  created_at: string;
-  updated_at: string;
-  resource: string;
-  resource_path: string;
-  committed: boolean;
-  fee: DepositWithdrawalAmountCurrency;
-  payout_at: string;
-}
-⋮----
-interface TransferAmount {
-  value: string;
-  currency: string;
-}
-⋮----
-interface TransferOwner {
-  id: string;
-  uuid: string;
-  user_uuid: string;
-  type: string;
-}
-⋮----
-interface TransferLedgerAccount {
-  account_id: string;
-  currency: string;
-  owner: TransferOwner;
-}
-⋮----
-interface TransferExternalPaymentMethod {
-  payment_method_id: string;
-}
-⋮----
-interface TransferSource {
-  type: string;
-  network: string;
-  payment_method_id: string;
-  external_payment_method: TransferExternalPaymentMethod;
-}
-⋮----
-interface TransferTarget {
-  type: string;
-  network: string;
-  payment_method_id: string;
-  ledger_account: TransferLedgerAccount;
-}
-⋮----
-interface TransferFee {
-  title: string;
-  description: string;
-  amount: TransferAmount;
-  type: string;
-}
-⋮----
-export interface CBAppTransferDepositWithdrawal {
-  user_entered_amount: TransferAmount;
-  amount: TransferAmount;
-  total: TransferAmount;
-  subtotal: TransferAmount;
-  idem: string;
-  committed: boolean;
-  id: string;
-  instant: boolean;
-  source: TransferSource;
-  target: TransferTarget;
-  payout_at: string;
-  status: string;
-  user_reference: string;
-  type: string;
-  created_at: string | null;
-  updated_at: string | null;
-  user_warnings: any[];
-  fees: any[];
-  total_fee: TransferFee;
-  cancellation_reason: string | null;
-  hold_days: number;
-  nextStep: any | null;
-  checkout_url: string;
-  requires_completion_step: boolean;
-}
-⋮----
-export interface CBAppTransfer {
-  transfer: CBAppTransferDepositWithdrawal;
-}
-/**
- *
- * DATA - Currencies Endpoints
- *
- */
-⋮----
-export interface CBAppFiatCurrency {
-  id: string;
-  name: string;
-  min_size: string;
-}
-⋮----
-export interface CBAppCryptocurrency {
-  code: string;
-  name: string;
-  color: string;
-  sort_index: number;
-  exponent: number;
-  type: string;
-  address_regex: string;
-  asset_id: string;
-}
-⋮----
-/**
- *
- * DATA- Exchange rates Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA - Prices Endpoints
- *
- */
-⋮----
-/**
- *
- * DATA - Time Endpoints
- *
- */
-
-================
 File: src/types/response/coinbase-exchange.ts
 ================
 /**
@@ -3651,319 +6719,6 @@ export interface CBExchCurrencySupportedNetwork {
  */
 
 ================
-File: src/types/response/coinbase-international.ts
-================
-/**
- *
- * Assets Endpoints
- *
- */
-⋮----
-/**
- *
- * Instruments Endpoints
- *
- */
-⋮----
-/**
- *
- * Position Offsets Endpoints
- *
- */
-⋮----
-/**
- *
- * Orders Endpoints
- *
- */
-⋮----
-/**
- *
- * Portfolios Endpoints
- *
- */
-⋮----
-/**
- *
- * Rankings Endpoints
- *
- */
-⋮----
-/**
- *
- * Transfers Endpoints
- *
- */
-⋮----
-/**
- *
- * Fee Rates Endpoints
- *
- */
-
-================
-File: src/types/response/coinbase-prime.ts
-================
-/**
- *
- * Allocation Endpoints
- *
- */
-⋮----
-/**
- *
- * Invoice Endpoints
- *
- */
-⋮----
-/**
- *
- * Assets Endpoints
- *
- */
-⋮----
-/**
- *
- * Payment Methods Endpoints
- *
- */
-⋮----
-/**
- *
- * Users Endpoints
- *
- */
-⋮----
-/**
- *
- * Portfolios Endpoints
- *
- */
-⋮----
-/**
- *
- * Activities Endpoints
- *
- */
-⋮----
-/**
- *
- * Address Book Endpoints
- *
- */
-⋮----
-/**
- *
- * Balances Endpoints
- *
- */
-⋮----
-/**
- *
- * Commission Endpoints
- *
- */
-⋮----
-/**
- *
- * Orders Endpoints
- *
- */
-⋮----
-/**
- *
- * Products Endpoints
- *
- */
-⋮----
-/**
- *
- * Transactions Endpoints
- *
- */
-⋮----
-/**
- *
- * Wallets Endpoints
- *
- */
-
-================
-File: src/types/response/ws.ts
-================
-export interface WsInfo {
-  endpoint: string;
-  encrypt: boolean;
-  protocol: string;
-  pingInterval: number;
-  pingTimeout: number;
-}
-
-================
-File: src/types/websockets/events.ts
-================
-import { WS_KEY_MAP } from '../../lib/websocket/websocket-util.js';
-⋮----
-export interface WsDataEvent<TData = any, TWSKey = string> {
-  data: TData;
-  table: string;
-  wsKey: TWSKey;
-}
-⋮----
-/**
- * General event structure for events from the advanced trade websocket
- */
-export interface CBAdvancedTradeEvent {
-  channel: string;
-  client_id: string;
-  timestamp: string;
-  sequence_num: number;
-  events: Record<'subscriptions', Record<string, string[]>>;
-}
-⋮----
-export interface CBAdvancedTradeErrorEvent {
-  type: 'error';
-  message: string;
-  wsKey:
-    | typeof WS_KEY_MAP.advTradeMarketData
-    | typeof WS_KEY_MAP.advTradeUserData;
-}
-⋮----
-/**
- * General event structure for events from the Coinbase Exchange websocket.
- * All Coinbase Exchange events extend this schema.
- */
-export interface CBExchangeBaseEvent {
-  type: 'subscriptions' | string;
-  wsKey:
-    | typeof WS_KEY_MAP.exchangeMarketData
-    | typeof WS_KEY_MAP.exchangeDirectMarketData;
-}
-⋮----
-/**
- * Sent after subscribing to one or more channels
- */
-export type CBExchangeSubscriptionsEvent = CBExchangeBaseEvent & {
-  type: 'subscriptions';
-  channels?: { name: string; product_ids: string[]; account_ids: null }[];
-};
-
-================
-File: src/types/websockets/requests.ts
-================
-/* eslint-disable @typescript-eslint/no-unused-vars */
-export type WsOperation = 'subscribe' | 'unsubscribe';
-⋮----
-/**
- * This is the format used for commands sent upstream for this websocket connection.
- *
- * Docs:
- * - Adv Trade: https://docs.cdp.coinbase.com/advanced-trade/docs/ws-auth#subscribing
- */
-export interface WsAdvTradeRequestOperation<TWSTopic extends string = string> {
-  type: WsOperation;
-  channel: TWSTopic;
-  product_ids?: string[];
-  jwt?: string;
-}
-⋮----
-export interface WsExchangeChannelWithParams<TWSTopic extends string = string> {
-  name: TWSTopic;
-  product_ids: string[];
-}
-⋮----
-/**
- * Public subscribe/unsubscribe requests for the Coinbase Exchange product group
- */
-export interface WsExchangeRequestOperation<TWSTopic extends string = string> {
-  type: WsOperation;
-  channels: (TWSTopic | WsExchangeChannelWithParams)[];
-  product_ids?: string[];
-}
-⋮----
-/**
- * Private (authenticated) subscribe/unsubscribe requests for the Coinbase Exchange product group
- * https://docs.cdp.coinbase.com/exchange/docs/websocket-auth
- */
-export type WsExchangeAuthenticatedRequestOperation<
-  TWSTopic extends string = string,
-> = WsExchangeRequestOperation<TWSTopic> & {
-  signature: string;
-  key: string;
-  passphrase: string;
-  timestamp: string;
-};
-⋮----
-/**
- * Public subscribe/unsubscribe requests for the Coinbase International product group
- */
-export interface WsInternationalRequestOperation<
-  TWSTopic extends string = string,
-> {
-  type: Uppercase<WsOperation>;
-  channels: TWSTopic[];
-  product_ids?: string[];
-}
-⋮----
-/**
- * Private (authenticated) subscribe/unsubscribe requests for the Coinbase International product group
- * https://docs.cdp.coinbase.com/intx/docs/websocket-auth
- */
-export type WsInternationalAuthenticatedRequestOperation<
-  TWSTopic extends string = string,
-> = WsInternationalRequestOperation<TWSTopic> & {
-  time: string;
-  key: string;
-  passphrase: string;
-  signature: string;
-};
-⋮----
-/**
- * Public subscribe/unsubscribe requests for the Coinbase Prime product group
- */
-export interface WsPrimeRequestOperation<TWSTopic extends string = string> {
-  type: WsOperation;
-  channel: TWSTopic;
-  // these should be provided as a payload with the request, else auth will fail
-  svcAccountId: string;
-  portfolio_id: string;
-  product_ids: string[];
-}
-⋮----
-// these should be provided as a payload with the request, else auth will fail
-⋮----
-/**
- * Private (authenticated) subscribe/unsubscribe requests for the Coinbase Prime product group
- *
- * - https://docs.cdp.coinbase.com/prime/docs/websocket-feed#signing-messages
- * - https://docs.cdp.coinbase.com/prime/docs/websocket-channels
- */
-export type WsPrimeAuthenticatedRequestOperation<
-  TWSTopic extends string = string,
-> = WsPrimeRequestOperation<TWSTopic> & {
-  access_key: string;
-  api_key_id: string;
-  passphrase: string;
-  signature: string;
-  timestamp: string;
-};
-
-================
-File: src/types/websockets/wsAPI.ts
-================
-export interface WsAPIWsKeyTopicMap {
-  [k: string]: never;
-}
-⋮----
-export interface WsAPITopicRequestParamMap {
-  [k: string]: never;
-}
-⋮----
-export interface WsAPITopicResponseMap {
-  [k: string]: never;
-}
-
-================
 File: src/types/shared.types.ts
 ================
 // Order configuration types
@@ -4083,7 +6838,7 @@ export interface OrderConfiguration {
 export type CustomOrderIdProperty = 'client_order_id' | 'client_oid';
 
 ================
-File: src/CBCommerceClient.ts
+File: src/CBAdvancedTradeClient.ts
 ================
 import { AxiosRequestConfig } from 'axios';
 ⋮----
@@ -4093,122 +6848,633 @@ import {
   RestClientOptions,
   RestClientType,
 } from './lib/requestUtils.js';
+import {
+  AllocateAdvTradePortfolioRequest,
+  CloseAdvTradePositionRequest,
+  GetAdvTradeFillsRequest,
+  GetAdvTradeMarketTradesRequest,
+  GetAdvTradeOrdersRequest,
+  GetAdvTradeProductCandlesRequest,
+  GetAdvTradeProductsRequest,
+  GetAdvTradePublicMarketTradesRequest,
+  GetAdvTradePublicProductCandlesRequest,
+  GetAdvTradePublicProductsRequest,
+  GetAdvTradeTransactionSummaryRequest,
+  MoveAdvTradePortfolioFundsRequest,
+  PreviewAdvTradeOrderRequest,
+  SubmitAdvTradeConvertQuoteRequest,
+  SubmitAdvTradeOrderRequest,
+  UpdateAdvTradeOrderRequest,
+} from './types/request/advanced-trade-client.js';
+import {
+  AdvTradeAccount,
+  AdvTradeAccountsList,
+  AdvTradeApiKeyPermissions,
+  AdvTradeCancelOrdersResponse,
+  AdvTradeCandle,
+  AdvTradeClosePositionResponse,
+  AdvTradeCurrentMarginWindow,
+  AdvTradeEditOrderPreviewResponse,
+  AdvTradeEditOrderResponse,
+  AdvTradeFill,
+  AdvTradeFuturesBalance,
+  AdvTradeFuturesPosition,
+  AdvTradeFuturesSweep,
+  AdvTradeMarketTrades,
+  AdvTradeOrder,
+  AdvTradeOrderPreview,
+  AdvTradePaymentMethod,
+  AdvTradePerpetualsPortfolio,
+  AdvTradePerpetualsPosition,
+  AdvTradePerpetualsPositionSummary,
+  AdvTradePortfolio,
+  AdvTradePortfolioBalance,
+  AdvTradePortfolioBreakdown,
+  AdvTradePricebook,
+  AdvTradeProduct,
+  AdvTradePublicProduct,
+  AdvTradeSubmitOrderResponse,
+  AdvTradeTransactionSummary,
+} from './types/response/advanced-trade-client.js';
 ⋮----
 /**
- * REST client for Coinbase Prime API:
- * https://docs.cdp.coinbase.com/commerce-onchain/docs/welcome
+ * REST client for Coinbase's Advanced Trade API:
+ * https://docs.cdp.coinbase.com/advanced-trade/docs/api-overview/
  */
-export class CBCommerceClient extends BaseRestClient
+export class CBAdvancedTradeClient extends BaseRestClient
 ⋮----
 constructor(
     restClientOptions: RestClientOptions = {},
     requestOptions: AxiosRequestConfig = {},
 )
 ⋮----
+/**
+   *
+   * Custom SDK functions
+   *
+   */
+⋮----
+/**
+   * This method is used to get the latency and time sync between the client and the server.
+   * This is not official API endpoint and is only used for internal testing purposes.
+   * Use this method to check the latency and time sync between the client and the server.
+   * Final values might vary slightly, but it should be within few ms difference.
+   * If you have any suggestions or improvements to this measurement, please create an issue or pull request on GitHub.
+   */
+async fetchLatencySummary(): Promise<any>
+⋮----
+// Adjust server time by adding estimated one-way latency
+⋮----
+// Calculate time difference between adjusted server time and local time
+⋮----
 getClientType(): RestClientType
 ⋮----
 /**
    *
-   * Charges Endpoints
+   * Account Endpoints
    *
    */
 ⋮----
 /**
-   * Creates a Charge
+   * List Accounts
    *
-   * Creates a charge.
+   * Get a list of authenticated accounts for the current user.
    */
-createCharge(params: {
-    buyer_locale?: string;
-    cancel_url?: string;
-    checkout_id?: string;
-    local_price: {
-      amount: string;
-      currency: string;
-    };
-    metadata?: {
-      custom_field?: string;
-      custom_field_two?: string;
-    };
-    pricing_type: string;
-    redirect_url?: string;
+getAccounts(params?: {
+    limit?: number;
+    cursor?: string;
+    retail_portfolio_id?: string; // deprecated
+}): Promise<AdvTradeAccountsList>
+⋮----
+retail_portfolio_id?: string; // deprecated
+⋮----
+/**
+   * Get Account
+   *
+   * Get a list of information about single account, given an account UUID.
+   * Tip: Use List Accounts (getAccounts funcion) to find account UUIDs.
+   */
+getAccount(params:
+⋮----
+/**
+   *
+   * Products Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Best Bid/Ask
+   *
+   * Get the best bid/ask for all products. A subset of all products can be returned instead by using the product_ids input.
+   */
+getBestBidAsk(params?:
+⋮----
+/**
+   * Get Product Book
+   *
+   * Get a list of bids/asks for a single product. The amount of detail shown can be customized with the limit parameter.
+   */
+getProductBook(params: {
+    product_id: string;
+    limit?: number;
+    aggregation_price_increment?: string;
+}): Promise<
+⋮----
+/**
+   * List Products
+   *
+   * Get a list of the available currency pairs for trading.
+   *
+   */
+getProducts(params?: GetAdvTradeProductsRequest): Promise<
+⋮----
+/**
+   * Get Product
+   *
+   * Get information on a single product by product ID.
+   */
+getProduct(params: {
+    product_id: string;
+    get_tradability_status?: boolean;
+}): Promise<AdvTradeProduct>
+⋮----
+/**
+   * Get Product Candles
+   *
+   * Get rates for a single product by product ID, grouped in buckets.
+   */
+getProductCandles(params: GetAdvTradeProductCandlesRequest): Promise<
+⋮----
+/**
+   * Get Market Trades
+   *
+   * Get snapshot information by product ID about the last trades (ticks) and best bid/ask.
+   */
+getMarketTrades(
+    params: GetAdvTradeMarketTradesRequest,
+): Promise<AdvTradeMarketTrades>
+⋮----
+/**
+   *
+   * Orders Endpoints
+   *
+   */
+⋮----
+/**
+   * Create Order
+   *
+   * Create an order with a specified product_id (asset-pair), side (buy/sell), etc.
+   *
+   */
+submitOrder(
+    params: SubmitAdvTradeOrderRequest,
+): Promise<AdvTradeSubmitOrderResponse>
+⋮----
+/**
+   * Cancel Orders
+   *
+   * Initiate cancel requests for one or more orders.
+   * The maximum number of order_ids that can be cancelled per request is 100.
+   * This number may be subject to change in emergency, but if a request exceeds the max,
+   * then an InvalidArgument error code will be returned with an error message denoting the limit.
+   */
+cancelOrders(params: {
+    order_ids: string[];
+}): Promise<AdvTradeCancelOrdersResponse>
+⋮----
+/**
+   * Edit Order
+   *
+   * Edit an order with a specified new size, or new price.
+   *
+   * - Your request moves to the back of the queue if you increase the size or increase or decrease the price.
+   * - If you decrease the size, you keep your place in line.
+   * - A client can only send an Edit Order request after the previous request for the same order has been fully processed.
+   */
+updateOrder(
+    params: UpdateAdvTradeOrderRequest,
+): Promise<AdvTradeEditOrderResponse>
+⋮----
+/**
+   * Edit Order Preview
+   *
+   * Preview an edit order request with a specified new size, or new price.
+   *
+   */
+updateOrderPreview(
+    params: UpdateAdvTradeOrderRequest,
+): Promise<AdvTradeEditOrderPreviewResponse>
+⋮----
+/**
+   * List Orders
+   *
+   * Get a list of orders filtered by optional query parameters.
+   *
+   * - The maximum number of OPEN orders returned is 1000.
+   * - The parameters start_date and end_date don't apply to open orders.
+   * - You cannot pair open orders with other order types.
+   * - You cannot query for OPEN orders with other order types.
+   */
+getOrders(params?: GetAdvTradeOrdersRequest): Promise<
+⋮----
+/**
+   * List Fills
+   *
+   * Get a list of fills filtered by optional query parameters (product_id, order_id, etc).
+   *
+   */
+getFills(params?: GetAdvTradeFillsRequest): Promise<
+⋮----
+/**
+   * Get Order
+   *
+   * Get a single order by order ID.
+   */
+getOrder(params: {
+    order_id: string;
+    client_order_id?: string;
+    user_native_currency?: string;
+}): Promise<
+⋮----
+/**
+   * Preview Order
+   *
+   * Preview an order.
+   *
+   */
+previewOrder(
+    params: PreviewAdvTradeOrderRequest,
+): Promise<AdvTradeOrderPreview>
+⋮----
+/**
+   * Close Position
+   *
+   * Places an order to close any open positions for a specified product_id.
+   *
+   */
+closePosition(
+    params: CloseAdvTradePositionRequest,
+): Promise<AdvTradeClosePositionResponse>
+⋮----
+/**
+   *
+   * Portfolios Endpoints
+   *
+   */
+⋮----
+/**
+   * List Portfolios
+   *
+   * Get all portfolios of a user.
+   */
+getPortfolios(params?: {
+    portfolio_type?: 'UNDEFINED' | 'DEFAULT' | 'CONSUMER' | 'INTX';
+}): Promise<
+⋮----
+/**
+   * Create Portfolio
+   *
+   * Create a portfolio.
+   */
+createPortfolio(params:
+⋮----
+/**
+   * Move Portfolio Funds
+   *
+   * Move funds between portfolios.
+   */
+movePortfolioFunds(params: MoveAdvTradePortfolioFundsRequest): Promise<
+⋮----
+/**
+   * Get Portfolio Breakdown
+   *
+   * Get the breakdown of a portfolio.
+   */
+getPortfolioBreakdown(params: {
+    portfolio_uuid: string;
+    currency?: string;
+}): Promise<
+⋮----
+/**
+   * Delete Portfolio
+   *
+   * Delete a portfolio.
+   */
+deletePortfolio(params:
+⋮----
+/**
+   * Edit Portfolio
+   *
+   * Edit a portfolio.
+   *
+   */
+updatePortfolio(params: {
+    portfolio_uuid: string;
+    name: string;
+}): Promise<
+⋮----
+/**
+   *
+   * Futures Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Futures Balance Summary
+   *
+   * Get a summary of balances for CFM trading.
+   *
+   * Futures vs Spot Accounts:
+   * - Futures and spot balances are held in different accounts.
+   * - Cash is always deposited into your Coinbase Inc. (CBI) spot account.
+   * - Cash is automatically transferred to your Coinbase Financial Markets (CFM) futures account to satisfy margin requirements.
+   * - You can transfer cash that isn't being used to margin or maintain futures positions into your CBI spot account.
+   * - Funds held in a CBI spot account do not receive the preferential treatment given to funds held in a regulated futures account.
+   *
+   * Intraday vs. Overnight Margin Health:
+   * - If you are opted in to receive increased leverage on futures trades during the intraday window (from 8am-4pm ET), this endpoint will return your intraday and overnight margin health.
+   */
+getFuturesBalanceSummary(): Promise<
+⋮----
+/**
+   * Get Intraday Margin Setting
+   *
+   * Get the futures intraday margin setting.
+   */
+getIntradayMarginSetting(): Promise<
+⋮----
+/**
+   * Set Intraday Margin Setting
+   *
+   * Set the futures intraday margin setting.
+   */
+setIntradayMarginSetting(params?: {
+    setting?:
+      | 'INTRADAY_MARGIN_SETTING_UNSPECIFIED'
+      | 'INTRADAY_MARGIN_SETTING_STANDARD'
+      | 'INTRADAY_MARGIN_SETTING_INTRADAY';
 }): Promise<any>
 ⋮----
 /**
-   * Returns All Charges
+   * Get Current Margin Window
    *
-   * Returns all charges.
+   * Get the futures current margin window.
    */
-getAllCharges(): Promise<any>
+getCurrentMarginWindow(params?: {
+    margin_profile_type?:
+      | 'MARGIN_PROFILE_TYPE_UNSPECIFIED'
+      | 'MARGIN_PROFILE_TYPE_RETAIL_REGULAR'
+      | 'MARGIN_PROFILE_TYPE_RETAIL_INTRADAY_MARGIN_1';
+}): Promise<AdvTradeCurrentMarginWindow>
 ⋮----
 /**
-   * Returns the Charge with the Order Code
+   * List Futures Positions
    *
-   * Returns the charge with the order code.
+   * Get a list of positions in CFM products.
    */
-getCharge(params:
+getFuturesPositions(): Promise<
+⋮----
+/**
+   * Get Futures Position
+   *
+   * Get positions for a specific CFM product.
+   */
+getFuturesPosition(params: {
+    product_id: string;
+}): Promise<
+⋮----
+/**
+   * Schedule Futures Sweep
+   *
+   * Schedules a sweep of funds from FCM wallet to USD Spot wallet.
+   *
+   * Futures Sweep Processing:
+   * - Sweep requests submitted before 5PM ET each day are processed the following business day.
+   * - Sweep requests submitted after 5PM ET each day are processed in 2 business days.
+   * - You can have at most one pending sweep request at a time.
+   *
+   * Market movements related to your open positions may impact the final amount that is transferred into your spot account.
+   * The final funds transferred, up to your specified amount, depend on the available excess in your futures account.
+   */
+scheduleFuturesSweep(params?: {
+    usd_amount?: string;
+}): Promise<
+⋮----
+/**
+   * List Futures Sweeps
+   *
+   * Get pending and processing sweeps of funds from FCM wallet to USD Spot wallet.
+   *
+   * Pending vs. Processing Sweeps:
+   * - A pending sweep is a sweep that has not started processing and can be cancelled.
+   * - A processing sweep is a sweep that is currently being processed and cannot be cancelled.
+   * - Once a sweep is complete, it no longer appears in the list of sweeps.
+   */
+getFuturesSweeps(): Promise<
+⋮----
+/**
+   * Cancel Pending Futures Sweep
+   *
+   * Cancel the pending sweep of funds from FCM wallet to USD Spot wallet.
+   */
+cancelPendingFuturesSweep(): Promise<
 ⋮----
 /**
    *
-   * Checkouts Endpoints
+   * Perpetuals Endpoints
    *
    */
 ⋮----
 /**
-   * Creates a New Checkout
+   * Allocate Portfolio
    *
-   * Creates a new checkout.
+   * Allocate portfolio funds to a sub-portfolio on Intx Portfolio.
+   *
    */
-createCheckout(params: {
-    buyer_locale?: string;
-    total_price: {
-      amount: string;
-      currency: string;
-    };
-    metadata?: {
-      custom_field?: string;
-      custom_field_two?: string;
-    };
-    pricing_type: string;
-    requested_info?: string[];
+allocatePortfolio(params: AllocateAdvTradePortfolioRequest): Promise<any>
+⋮----
+/**
+   * Get Perpetuals Portfolio Summary
+   *
+   * Get a summary of your Perpetuals portfolio.
+   */
+getPerpetualsPortfolioSummary(params: {
+    portfolio_uuid: string;
+}): Promise<AdvTradePerpetualsPortfolio>
+⋮----
+/**
+   * List Perpetuals Positions
+   *
+   * Get a list of open positions in your Perpetuals portfolio.
+   */
+getPerpetualsPositions(params: {
+    portfolio_uuid: string;
+}): Promise<AdvTradePerpetualsPositionSummary>
+⋮----
+/**
+   * Get Perpetuals Position
+   *
+   * Get a specific open position on Intx.
+   *
+   */
+getPerpetualsPosition(params: {
+    portfolio_uuid: string;
+    symbol: string;
+}): Promise<
+⋮----
+/**
+   * Get Portfolios Balances
+   *
+   * Get a list of asset balances on Intx for a given Portfolio.
+   */
+getPortfoliosBalances(params:
+⋮----
+/**
+   * Opt In or Out of Multi Asset Collateral
+   *
+   * Enable or Disable Multi Asset Collateral for a given Portfolio.
+   */
+updateMultiAssetCollateral(params?: {
+    portfolio_uuid?: string;
+    multi_asset_collateral_enabled?: boolean;
+}): Promise<
+⋮----
+/**
+   *
+   * Fees Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Transaction Summary
+   *
+   * Get a summary of transactions with fee tiers, total volume, and fees.
+   */
+getTransactionSummary(
+    params?: GetAdvTradeTransactionSummaryRequest,
+): Promise<AdvTradeTransactionSummary>
+⋮----
+/**
+   *
+   * Converts Endpoints
+   *
+   */
+⋮----
+/**
+   * Create Convert Quote
+   *
+   * Create a convert quote with a specified source account, target account, and amount.
+   * Convert is applicable for USDC-USD and EURC-EUR conversion.
+   */
+submitConvertQuote(params: SubmitAdvTradeConvertQuoteRequest): Promise<any>
+⋮----
+/**
+   * Get Convert Trade
+   *
+   * Gets a list of information about a convert trade with a specified trade id, source account, and target account.
+   */
+getConvertTrade(params: {
+    trade_id: string;
+    from_account: string;
+    to_account: string;
 }): Promise<any>
 ⋮----
 /**
-   * Returns All Checkout Sessions
+   * Commit Convert Trade
    *
-   * Returns all checkout sessions.
+   * Commits a convert trade with a specified trade id, source account, and target account.
    */
-getAllCheckouts(): Promise<any>
-⋮----
-/**
-   * Returns a Specific Checkout Session
-   *
-   * Returns a specific checkout session.
-   */
-getCheckout(params:
+commitConvertTrade(params: {
+    trade_id: string;
+    from_account: string;
+    to_account: string;
+}): Promise<any>
 ⋮----
 /**
    *
-   * Events Endpoints
+   * Public Endpoints
+   *
+   */
+⋮----
+getServerTime(): Promise<
+⋮----
+/**
+   * Get Public Product Book
+   *
+   * Get a list of bids/asks for a single product. The amount of detail shown can be customized with the limit parameter.
+   */
+getPublicProductBook(params: {
+    product_id: string;
+    limit?: number;
+    aggregation_price_increment?: string;
+}): Promise<
+⋮----
+/**
+   * List Public Products
+   *
+   * Get a list of the available currency pairs for trading.
+   */
+getPublicProducts(params?: GetAdvTradePublicProductsRequest): Promise<
+⋮----
+/**
+   * Get Public Product
+   *
+   * Get information on a single product by product ID.
+   */
+getPublicProduct(params: {
+    product_id: string;
+}): Promise<AdvTradePublicProduct>
+⋮----
+/**
+   * Get Public Product Candles
+   *
+   * Get rates for a single product by product ID, grouped in buckets.
+   */
+getPublicProductCandles(
+    params: GetAdvTradePublicProductCandlesRequest,
+): Promise<
+⋮----
+/**
+   * Get Public Market Trades
+   *
+   * Get snapshot information by product ID about the last trades (ticks) and best bid/ask.
+   */
+getPublicMarketTrades(
+    params: GetAdvTradePublicMarketTradesRequest,
+): Promise<AdvTradeMarketTrades>
+⋮----
+/**
+   *
+   * Payment Methods Endpoints
    *
    */
 ⋮----
 /**
-   * List Events
+   * List Payment Methods
    *
-   * Lists all events.
+   * Get a list of payment methods for the current user.
    */
-listEvents(headers:
+getPaymentMethods(): Promise<
 ⋮----
 /**
-   * Show an Event
+   * Get Payment Method
    *
-   * Retrieves the details of an event. Supply the unique identifier of the event, which you might have received in a webhook.
+   * Get information about a payment method for the current user.
    */
-showEvent(
-    params: { event_id: string },
-    headers: { 'X-CC-Version': string },
-): Promise<any>
+getPaymentMethod(params:
+⋮----
+/**
+   *
+   * Data API Endpoints
+   *
+   */
+⋮----
+/**
+   * Get API Key Permissions
+   *
+   * Get information about your CDP API key permissions.
+   */
+getApiKeyPermissions(): Promise<AdvTradeApiKeyPermissions>
 
 ================
 File: src/CBExchangeClient.ts
@@ -4979,577 +8245,6 @@ getWrappedAssetConversionRate(params: {
 }): Promise<any>
 
 ================
-File: src/CBInternationalClient.ts
-================
-import { AxiosRequestConfig } from 'axios';
-⋮----
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import {
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-} from './lib/requestUtils.js';
-import {
-  CancelINTXOrdersRequest,
-  GetINTXAggregatedCandlesData,
-  GetINTXDailyTradingVolumes,
-  GetINTXFillsByPortfoliosRequest,
-  GetINTXIndexCandlesRequest,
-  GetINTXIndexCompositionHistory,
-  GetINTXMatchingTransfersRequest,
-  GetINTXOpenOrdersRequest,
-  GetINTXPortfolioFillsRequest,
-  INTXWithdrawToCounterpartyIdRequest,
-  INTXWithdrawToCryptoAddressRequest,
-  SubmitINTXOrderRequest,
-  TransferINTXFundsBetweenPortfoliosRequest,
-  TransferINTXPositionsBetweenPortfoliosRequest,
-  UpdateINTXOpenOrderRequest,
-  UpdateINTXPortfolioParametersRequest,
-} from './types/request/coinbase-international.js';
-⋮----
-/**
- * REST client for Coinbase's Institutional International Exchange API:
- * https://docs.cdp.coinbase.com/intx/docs/welcome
- */
-export class CBInternationalClient extends BaseRestClient
-⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   *
-   * Assets Endpoints
-   *
-   */
-⋮----
-/**
-   * List assets
-   *
-   * Returns a list of all supported assets.
-   */
-getAssets(): Promise<any>
-⋮----
-/**
-   * Get asset details
-   *
-   * Retrieves information for a specific asset.
-   */
-getAssetDetails(params:
-⋮----
-/**
-   * Get supported networks per asset
-   *
-   * Returns a list of supported networks and network information for a specific asset.
-   */
-getSupportedNetworksPerAsset(params:
-⋮----
-/**
-   *
-   * Index Endpoints
-   *
-   */
-⋮----
-/**
-   * Get index composition
-   *
-   * Retrieves the latest index composition (metadata) with an ordered set of constituents.
-   */
-getIndexComposition(params:
-⋮----
-/**
-   * Get index composition history
-   *
-   * Retrieves a history of index composition records in a descending time order.
-   * The results are an array of index composition data recorded at different "timestamps".
-   */
-getIndexCompositionHistory(
-    params: GetINTXIndexCompositionHistory,
-): Promise<any>
-⋮----
-/**
-   * Get index price
-   *
-   * Retrieves the latest index price.
-   */
-getIndexPrice(params:
-⋮----
-/**
-   * Get index candles
-   *
-   * Retrieves the historical daily index prices in time descending order.
-   * The daily values are represented as aggregated entries for the day in typical OHLC format.
-   */
-getIndexCandles(params: GetINTXIndexCandlesRequest): Promise<any>
-⋮----
-/**
-   *
-   * Instruments Endpoints
-   *
-   */
-⋮----
-/**
-   * List instruments
-   *
-   * Returns all of the instruments available for trading.
-   */
-getInstruments(): Promise<any>
-⋮----
-/**
-   * Get instrument details
-   *
-   * Retrieves market information for a specific instrument.
-   */
-getInstrumentDetails(params:
-⋮----
-/**
-   * Get quote per instrument
-   *
-   * Retrieves the current quote for a specific instrument.
-   */
-getQuotePerInstrument(params:
-⋮----
-/**
-   * Get daily trading volumes
-   *
-   * Retrieves the trading volumes for each instrument separated by day.
-   */
-getDailyTradingVolumes(params: GetINTXDailyTradingVolumes): Promise<any>
-⋮----
-/**
-   * Get aggregated candles data per instrument
-   *
-   * Retrieves a list of aggregated candles data for a given instrument, granularity, and time range.
-   */
-getAggregatedCandlesData(params: GetINTXAggregatedCandlesData): Promise<any>
-⋮----
-/**
-   * Get historical funding rates
-   *
-   * Retrieves the historical funding rates for a specific instrument.
-   */
-getHistoricalFundingRates(params: {
-    instrument: string;
-    result_limit?: number;
-    result_offset?: number;
-}): Promise<any>
-⋮----
-/**
-   *
-   * Position Offsets Endpoints
-   *
-   */
-⋮----
-/**
-   * List position offsets
-   *
-   * Returns all active position offsets.
-   */
-getPositionOffsets(): Promise<any>
-⋮----
-/**
-   *
-   * Orders Endpoints
-   *
-   */
-⋮----
-/**
-   * Create order
-   *
-   * Creates a new order.
-   */
-submitOrder(params: SubmitINTXOrderRequest): Promise<any>
-⋮----
-/**
-   * List open orders
-   *
-   * Returns a list of active orders resting on the order book matching the requested criteria.
-   * Does not return any rejected, cancelled, or fully filled orders as they are not active.
-   */
-getOpenOrders(params?: GetINTXOpenOrdersRequest): Promise<any>
-⋮----
-/**
-   * Cancel orders
-   *
-   * Cancels all orders matching the requested criteria.
-   */
-cancelOrders(params: CancelINTXOrdersRequest): Promise<any>
-⋮----
-/**
-   * Modify open order
-   *
-   * Modifies an open order.
-   */
-updateOpenOrder(params: UpdateINTXOpenOrderRequest): Promise<any>
-⋮----
-/**
-   * Get order details
-   *
-   * Retrieves a single order. The order retrieved can be either active or inactive.
-   */
-getOrderDetails(params:
-⋮----
-/**
-   * Cancel order
-   *
-   * Cancels a single open order.
-   */
-cancelOrder(params:
-⋮----
-/**
-   *
-   * Portfolios Endpoints
-   *
-   */
-⋮----
-/**
-   * List all user portfolios
-   *
-   * Returns all of the user's portfolios.
-   */
-getUserPortfolios(): Promise<any>
-⋮----
-/**
-   * Create portfolio
-   *
-   * Create a new portfolio. Request will fail if no name is provided or if user already has max number of portfolios. Max number of portfolios is 20.
-   */
-createPortfolio(params:
-⋮----
-/**
-   * Patch portfolio
-   *
-   * Update parameters for existing portfolio.
-   */
-updatePortfolioParameters(
-    params: UpdateINTXPortfolioParametersRequest,
-): Promise<any>
-⋮----
-/**
-   * Get user portfolio
-   *
-   * Returns the user's specified portfolio.
-   */
-getUserPortfolio(params:
-⋮----
-/**
-   * Update portfolio
-   *
-   * Update existing user portfolio.
-   */
-updatePortfolio(params:
-⋮----
-/**
-   * Get portfolio details
-   *
-   * Retrieves the summary, positions, and balances of a portfolio.
-   */
-getPortfolioDetails(params:
-⋮----
-/**
-   * Get portfolio summary
-   *
-   * Retrieves the high level overview of a portfolio.
-   */
-getPortfolioSummary(params:
-⋮----
-/**
-   * List portfolio balances
-   *
-   * Returns all of the balances for a given portfolio.
-   */
-getPortfolioBalances(params:
-⋮----
-/**
-   * Get balance for portfolio/asset
-   *
-   * Retrieves the balance for a given portfolio and asset.
-   */
-getBalanceForPortfolioAsset(params: {
-    portfolio: string;
-    asset: string;
-}): Promise<any>
-⋮----
-/**
-   * List active loans for the portfolio
-   *
-   * Retrieves all loan info for a given portfolio.
-   */
-getActiveLoansForPortfolio(params:
-⋮----
-/**
-   * Get loan info for portfolio/asset
-   *
-   * Retrieves the loan info for a given portfolio and asset.
-   */
-getLoanInfoForPortfolioAsset(params: {
-    portfolio: string;
-    asset: string;
-}): Promise<any>
-⋮----
-/**
-   * Acquire/repay loan
-   *
-   * Acquire or repay loan for a given portfolio and asset.
-   */
-acquireOrRepayLoan(params: {
-    portfolio: string;
-    asset: string;
-    amount: number;
-    action: 'ACQUIRE' | 'REPAY';
-}): Promise<any>
-⋮----
-/**
-   * Preview loan update
-   *
-   * Preview acquire or repay loan for a given portfolio and asset.
-   */
-previewLoanUpdate(params: {
-    portfolio: string;
-    asset: string;
-    action: 'ACQUIRE' | 'REPAY';
-    amount: string;
-}): Promise<any>
-⋮----
-/**
-   * View max loan availability
-   *
-   * View the maximum amount of loan that could be acquired now for a given portfolio and asset.
-   */
-getMaxLoanAvailability(params: {
-    portfolio: string;
-    asset: string;
-}): Promise<any>
-⋮----
-/**
-   * List portfolio positions
-   *
-   * Returns all of the positions for a given portfolio.
-   */
-getPortfolioPositions(params:
-⋮----
-/**
-   * Get position for portfolio/instrument
-   *
-   * Retrieves the position for a given portfolio and symbol.
-   */
-getPositionForPortfolioInstrument(params: {
-    portfolio: string;
-    instrument: string;
-}): Promise<any>
-⋮----
-/**
-   * Get total open position limit
-   *
-   * Retrieves the total open position limit across instruments for a given portfolio.
-   */
-getTotalOpenPositionLimit(params:
-⋮----
-/**
-   * List open position limits for all instruments
-   *
-   * Retrieves position limits for all positions a given portfolio currently has or has opened in the past.
-   */
-getOpenPositionLimitsForAllInstruments(params: {
-    portfolio: string;
-}): Promise<any>
-⋮----
-/**
-   * Get open position limits for portfolio instrument
-   *
-   * Retrieves the position limits for a given portfolio and symbol.
-   */
-getOpenPositionLimitsForInstrument(params: {
-    portfolio: string;
-    instrument: string;
-}): Promise<any>
-⋮----
-/**
-   * List fills by portfolios
-   *
-   * Returns fills for specified portfolios or fills for all portfolios if none are provided.
-   */
-getFillsByPortfolios(params?: GetINTXFillsByPortfoliosRequest): Promise<any>
-⋮----
-/**
-   * List portfolio fills
-   *
-   * Returns all of the fills for a given portfolio.
-   */
-getPortfolioFills(params: GetINTXPortfolioFillsRequest): Promise<any>
-⋮----
-/**
-   * Enable/Disable portfolio cross collateral
-   *
-   * Enable or disable the cross collateral feature for the portfolio, which allows the portfolio to use non-USDC assets as collateral for margin trading.
-   */
-setCrossCollateral(params: {
-    portfolio: string;
-    enabled: boolean;
-}): Promise<any>
-⋮----
-/**
-   * Enable/Disable portfolio auto margin mode
-   *
-   * Enable or disable the auto margin feature, which lets the portfolio automatically
-   * post margin amounts required to exceed the high leverage position restrictions.
-   */
-setAutoMargin(params:
-⋮----
-/**
-   * Set portfolio margin override
-   *
-   * Specify the margin override value for a portfolio to either increase notional requirements or opt-in to higher leverage.
-   */
-setPortfolioMarginOverride(params: {
-    portfolio_id: string;
-    margin_override: string;
-}): Promise<any>
-⋮----
-/**
-   * Get fund transfer limit between portfolios
-   *
-   * Retrieves the maximum amount that can be transferred between portfolios for a specific asset.
-   * This applies to transfers between portfolios of the same beneficial owner.
-   */
-getFundTransferLimit(params: {
-    portfolio: string;
-    asset: string;
-}): Promise<any>
-⋮----
-/**
-   * Transfer funds between portfolios
-   *
-   * Transfer assets from one portfolio to another.
-   */
-transferFundsBetweenPortfolios(
-    params: TransferINTXFundsBetweenPortfoliosRequest,
-): Promise<any>
-⋮----
-/**
-   * Transfer positions between portfolios
-   *
-   * Transfer an existing position from one portfolio to another. The position transfer must fulfill the same portfolio-level margin requirements as submitting a new order on the opposite side for the sender's portfolio and a new order on the same side for the recipient's portfolio.
-   * Additionally, organization-level requirements must be satisfied when evaluating the outcome of the position transfer.
-   */
-transferPositionsBetweenPortfolios(
-    params: TransferINTXPositionsBetweenPortfoliosRequest,
-): Promise<any>
-⋮----
-/**
-   * List portfolio fee rates
-   *
-   * Retrieves the Perpetual Future and Spot fee rate tiers for the user.
-   */
-getPortfolioFeeRates(): Promise<any>
-/**
-   *
-   * Rankings Endpoints
-   *
-   */
-⋮----
-/**
-   * Get your rankings
-   *
-   * Retrieve your volume rankings for maker, taker, and total volume.
-   */
-getRankings(params: {
-    instrument_type: string;
-    period?: string;
-    instruments?: string;
-}): Promise<any>
-⋮----
-/**
-   *
-   * Transfers Endpoints
-   *
-   */
-⋮----
-/**
-   * List matching transfers
-   *
-   * List matching transfers.
-   */
-getMatchingTransfers(params?: GetINTXMatchingTransfersRequest): Promise<any>
-⋮----
-/**
-   * Get transfer
-   *
-   * Get transfer.
-   */
-getTransfer(params:
-⋮----
-/**
-   * Withdraw to crypto address
-   *
-   * Withdraw to crypto address.
-   */
-withdrawToCryptoAddress(
-    params: INTXWithdrawToCryptoAddressRequest,
-): Promise<any>
-⋮----
-/**
-   * Create crypto address
-   *
-   * Create crypto address.
-   */
-createCryptoAddress(params: {
-    portfolio: string;
-    asset: string;
-    network_arn_id: string;
-}): Promise<any>
-⋮----
-/**
-   * Create counterparty Id
-   *
-   * Create counterparty Id.
-   */
-createCounterpartyId(params:
-⋮----
-/**
-   * Validate counterparty Id
-   *
-   * Validate counterparty Id.
-   */
-validateCounterpartyId(params:
-⋮----
-/**
-   * Get counterparty withdrawal limit
-   *
-   * Retrieves the maximum amount that can be withdrawn to a counterparty within the Coinbase transfer network
-   * for a specific portfolio and asset.
-   */
-getCounterpartyWithdrawalLimit(params: {
-    portfolio: string;
-    asset: string;
-}): Promise<any>
-⋮----
-/**
-   * Withdraw to counterparty Id
-   *
-   * Withdraw to counterparty Id.
-   */
-withdrawToCounterpartyId(
-    params: INTXWithdrawToCounterpartyIdRequest,
-): Promise<any>
-/**
-   *
-   * Fee Rates Endpoints
-   *
-   */
-⋮----
-/**
-   * List fee rate tiers
-   *
-   * Return all the fee rate tiers.
-   */
-getFeeRateTiers(): Promise<any>
-
-================
 File: src/CBPrimeClient.ts
 ================
 import { AxiosRequestConfig } from 'axios';
@@ -5592,6 +8287,7 @@ import {
   GetPrimePortfolioUsersRequest,
   GetPrimePortfolioWalletsRequest,
   GetPrimePortfolioWithdrawalPowerRequest,
+  GetPrimeTransactionTravelRuleDataRequest,
   GetPrimeUsersRequest,
   GetPrimeWalletDepositInstructionsRequest,
   GetPrimeWalletTransactionsRequest,
@@ -5599,6 +8295,7 @@ import {
   RotatePrimeApiKeyRequest,
   SubmitPrimeOrderRequest,
 } from './types/request/coinbase-prime.js';
+import { GetPrimeTransactionTravelRuleDataResponse } from './types/response/coinbase-prime.js';
 ⋮----
 /**
  * REST client for Coinbase Prime API:
@@ -6114,6 +8811,21 @@ getTransactionById(params: {
 }): Promise<any>
 ⋮----
 /**
+   *
+   * Travel Rule Endpoints
+   *
+   */
+⋮----
+/**
+   * Get Transaction Travel Rule Data
+   *
+   * (Beta) Get fulfilled travel rule data for a transaction.
+   */
+getTransactionTravelRuleData(
+    params: GetPrimeTransactionTravelRuleDataRequest,
+): Promise<GetPrimeTransactionTravelRuleDataResponse>
+⋮----
+/**
    * Create Conversion
    *
    * Perform a conversion between 2 assets.
@@ -6183,1938 +8895,6 @@ getWalletDepositInstructions(
 ): Promise<any>
 
 ================
-File: src/index.ts
-================
-
-
-================
-File: .prettierrc
-================
-{
-  "tabWidth": 2,
-  "singleQuote": true,
-  "trailingComma": "all"
-}
-
-================
-File: index.js
-================
-
-
-================
-File: postBuild.sh
-================
-#!/bin/bash
-#
-#   Add package.json files to cjs/mjs subtrees
-#
-
-cat >dist/cjs/package.json <<!EOF
-{
-    "type": "commonjs"
-}
-!EOF
-
-cat >dist/mjs/package.json <<!EOF
-{
-    "type": "module"
-}
-!EOF
-
-find src -name '*.d.ts' -exec cp {} dist/mjs \;
-find src -name '*.d.ts' -exec cp {} dist/cjs \;
-
-================
-File: tsconfig.cjs.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext"
-  },
-  "include": ["src/**/*.*"]
-}
-
-================
-File: tsconfig.esm.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "esnext",
-    "outDir": "dist/mjs",
-    "target": "esnext"
-  },
-  "include": ["src/**/*.*"]
-}
-
-================
-File: tsconfig.linting.json
-================
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "module": "commonjs",
-    "outDir": "dist/cjs",
-    "target": "esnext",
-    "rootDir": "../",
-    "allowJs": true
-  },
-  "include": [
-    "src/**/*.*",
-    "test/**/*.*",
-    "examples/**/*.*",
-    ".eslintrc.cjs",
-    "jest.config.ts"
-  ]
-}
-
-================
-File: examples/AdvancedTrade/Private/closePosition.ts
-================
-import { CBAdvancedTradeClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-// this function is suggested to used with spot market orders
-// If you want to close futures, it is recommended to use submitOrder() with the opposite side of the current position
-⋮----
-/* Closing Futures Positions - Exchange docs
-When a contract expires, we automatically close your open position at the exchange settlement price.
-You can also close your position before the contract expires
-(for example, you may want to close your position if you’ve reached your profit target,
-you want to prevent further losses, or you need to satisfy a margin requirement).
-
-There are two ways to close your futures positions:
-(1) Close your position with this endpoint, or
-(2) Create a separate trade to take the opposite position in the same futures contract you are currently holding in your account.
-For example, to close an open long position in the BTC 23 Feb 24 contract, place an order to sell the same number of BTC 23 Feb 24 contracts.
-If you were short to begin with, go long the same number of contracts to close your position.
-
-More info on https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_closeposition#closing-futures-positions */
-⋮----
-async function closePosition()
-⋮----
-// close position
-⋮----
-//
-
-================
-File: examples/AdvancedTrade/Private/getAccounts.ts
-================
-import { CBAdvancedTradeClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function getAccounts()
-⋮----
-// Get all accounts
-⋮----
-// Get specific account details
-
-================
-File: examples/AdvancedTrade/Private/getOrders.ts
-================
-import { CBAdvancedTradeClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function getOrders()
-⋮----
-// Get all orders
-⋮----
-// Get order details
-
-================
-File: examples/AdvancedTrade/Private/submitOrderPerps.ts
-================
-import { CBAdvancedTradeClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function submitOrder()
-⋮----
-// submit market futures order
-⋮----
-//
-⋮----
-async function submitLimitOrder()
-⋮----
-// Submit limit futures order
-
-================
-File: examples/AdvancedTrade/Private/submitOrderSpot.ts
-================
-import { CBAdvancedTradeClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function submitOrder()
-⋮----
-// submit market spot order
-⋮----
-//
-⋮----
-async function submitLimitOrder()
-⋮----
-// Submit limit spot order
-
-================
-File: examples/CoinbaseApp/Private/cb-app-private.ts
-================
-/**
- * import { CBAppClient } from 'coinbase-api';
- * const { CBAppClient } = require('coinbase-api');
- */
-⋮----
-import { CBAppClient } from '../../../src/index.js';
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function main()
-⋮----
-// Deposit funds to your fiat account
-⋮----
-// Withdraw funds from fiat account
-⋮----
-// Send money to another user
-⋮----
-// Transfer money between your own accounts
-
-================
-File: examples/CoinbaseApp/Private/depositFunds.ts
-================
-import { CBAppClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAppClient } from 'coinbase-api';
- * const { CBAppClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function depositFunds()
-⋮----
-// Deposit funds to your fiat account
-
-================
-File: examples/CoinbaseApp/Private/sendMoney.ts
-================
-import { CBAppClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAppClient } from 'coinbase-api';
- * const { CBAppClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function sendMoney()
-⋮----
-// Send money to another user
-
-================
-File: examples/CoinbaseApp/Private/transferMoney.ts
-================
-import { CBAppClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAppClient } from 'coinbase-api';
- * const { CBAppClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function transferMoney()
-⋮----
-// Transfer money between your own accounts
-
-================
-File: examples/CoinbaseApp/Private/withdrawFunds.ts
-================
-import { CBAppClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBAppClient } from 'coinbase-api';
- * const { CBAppClient } = require('coinbase-api');
- */
-⋮----
-// initialise the client
-/**
- *
- * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
- *
- * ECDSA:
- *
- * {
- *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
- *   apiSecret:
- *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
- * }
- *
- * ED25519:
- * {
- *   apiKey: 'your-api-key-id',
- *   apiSecret: 'yourExampleApiSecretEd25519Version==',
- * }
- *
- *
- */
-⋮----
-async function withdrawFunds()
-⋮----
-// Withdraw funds from your fiat account
-
-================
-File: examples/Institutional/CBExchange/Rest/cb-exchange-private.ts
-================
-import { CBExchangeClient } from '../../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// Initialize the client, you can pass in api keys here if you have them but they are not required for public endpoints
-⋮----
-//This is the passphrase you provided when creating this API key. NOT your account password.
-⋮----
-// Optional, connect to sandbox instead: https://public-sandbox.exchange.coinbase.com/apikeys
-// useSandbox: true,
-⋮----
-async function privateExchangeCalls()
-
-================
-File: examples/Institutional/CBExchange/Rest/cb-exchange-public.ts
-================
-import { CBExchangeClient } from '../../../../src/index.js';
-⋮----
-/**
- * import { CBAdvancedTradeClient } from 'coinbase-api';
- * const { CBAdvancedTradeClient } = require('coinbase-api');
- */
-⋮----
-// Initialize the client, you can pass in api keys here if you have them but they are not required for public endpoints
-⋮----
-async function publicExchangeCalls()
-⋮----
-// Get all known currencies
-⋮----
-// Get a single currency by id
-⋮----
-// Get all known trading pairs
-⋮----
-// Get all product volume
-⋮----
-// Get all wrapped assets
-
-================
-File: examples/Institutional/CBExchange/WebSockets/privateWs.ts
-================
-import { WebsocketClient } from '../../../../src/index.js';
-⋮----
-/**
- * import { WebsocketClient } from 'coinbase-api';
- * const { WebsocketClient } = require('coinbase-api');
- */
-⋮----
-async function start()
-⋮----
-//This is the passphrase you provided when creating this API key. NOT your account password.
-⋮----
-// Optional, connect to sandbox instead: https://public-sandbox.exchange.coinbase.com/apikeys
-// useSandbox: true,
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-/**
-     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
-     * - You can subscribe to topics one at a time or many one one request.
-     * - Topics can be sent as simple strings, if no parameters are required.
-     * - If parameters are required, pass them in the "payload" property - they will be merged into the subscription request automatically
-     * - Any subscribe requests on the "exchangeDirectMarketData" market are automatically authenticated with the available credentials
-     */
-⋮----
-/**
-     * Other examples for some of the authenticated Coinbase Exchange "direct market data" channels:
-     */
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#full-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#user-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#level2-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#balance-channel
-
-================
-File: examples/Institutional/CBExchange/WebSockets/publicWs.ts
-================
-import { WebsocketClient } from '../../../../src/index.js';
-⋮----
-/**
- * import { WebsocketClient } from 'coinbase-api';
- * const { WebsocketClient } = require('coinbase-api');
- */
-⋮----
-async function start()
-⋮----
-/**
-   * All websockets are available via the unified WebsocketClient.
-   *
-   * Below are examples specific to websockets in this product group.
-   */
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-/**
-     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
-     *
-     * - You can subscribe to topics one at a time or many one one request.
-     * - Topics can be sent as simple strings, if no parameters are required.
-     * - Coinbase Market Data is the traditional feed which is available without authentication.
-     * - To use this feed, use 'exchangeMarketData' as the wsKey for each subscription command:
-     */
-// client.subscribe('status', 'exchangeMarketData');
-⋮----
-/**
-     * Or send a more structured object with parameters, e.g. if parameters are required
-     */
-// const tickerSubscribeRequest: WsTopicRequest = {
-//   topic: 'ticker',
-//   /**
-//    * Anything in the payload will be merged into the subscribe "request",
-//    * allowing you to send misc parameters supported by the exchange (such as `product_ids: string[]`)
-//    */
-//   payload: {
-//     product_ids: ['ETH-USD', 'ETH-EUR'],
-//   },
-// };
-// client.subscribe(tickerSubscribeRequest, 'exchangeMarketData');
-⋮----
-/**
-     * Subscribe to the "heartbeat" topic for a few symbols
-     */
-// client.subscribe(
-//   {
-//     topic: 'heartbeat',
-//     payload: {
-//       product_ids: ['ETH-USD', 'BTC-USD'],
-//     },
-//   },
-//   'exchangeMarketData',
-// );
-⋮----
-// client.subscribe(
-//   {
-//     topic: 'level2',
-//     payload: {
-//       product_ids: ['ETH-USD', 'BTC-USD'],
-//     },
-//   },
-//   'exchangeMarketData',
-// );
-⋮----
-// /**
-//  * Or, send an array of structured objects with parameters, if you wanted to send multiple in one request
-//  */
-// // client.subscribe([level2SubscribeRequest, anotherRequest, etc], 'advTradeMarketData');
-⋮----
-/**
-     * Other Coinbase Exchange public websocket topics:
-     */
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#heartbeat-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#status-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#auction-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#matches-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#rfq-matches-channel
-⋮----
-// Optional:
-// product_ids: ['ETH-USD', 'BTC-USD'],
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#ticker-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#ticker-batch-channel
-⋮----
-// https://docs.cdp.coinbase.com/exchange/docs/websocket-channels#level2-batch-channel
-
-================
-File: examples/Institutional/CBInternationalExchange/cb-intx-public.ts
-================
-import { CBInternationalClient } from '../../../src/index.js';
-⋮----
-/**
- * import { CBInternationalClient } from 'coinbase-api';
- * const { CBInternationalClient } = require('coinbase-api');
- */
-⋮----
-// Initialize the client, you can pass in api keys here if you have them but they are not required for public endpoints
-⋮----
-async function publicInternationalCalls()
-⋮----
-// List assets
-⋮----
-// Get asset details
-⋮----
-// Get supported networks per asset
-⋮----
-// List instruments
-⋮----
-// Get instrument details
-⋮----
-// Get quote per instrument
-⋮----
-// Get daily trading volumes
-⋮----
-// Get aggregated candles data per instrument
-⋮----
-// Get historical funding rates
-⋮----
-// List position offsets
-
-================
-File: examples/Institutional/CBInternationalExchange/cb-intx-ws.ts
-================
-import { WebsocketClient, WsTopicRequest } from '../../../src/index.js';
-⋮----
-/**
- * import { WebsocketClient, WsTopicRequest } from 'coinbase-api';
- * const { WebsocketClient, WsTopicRequest } = require('coinbase-api');
- */
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-topic: 'LEVEL1', // ws topic
-/**
-   * Anything in the payload will be merged into the subscribe "request",
-   * allowing you to send misc parameters supported by the exchange (such as `product_ids: string[]`)
-   */
-
-================
-File: src/CBAdvancedTradeClient.ts
-================
-import { AxiosRequestConfig } from 'axios';
-⋮----
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import {
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-} from './lib/requestUtils.js';
-import {
-  AllocateAdvTradePortfolioRequest,
-  CloseAdvTradePositionRequest,
-  EditAdvTradeOrderRequest,
-  GetAdvTradeFillsRequest,
-  GetAdvTradeMarketTradesRequest,
-  GetAdvTradeOrdersRequest,
-  GetAdvTradeProductCandlesRequest,
-  GetAdvTradeProductsRequest,
-  GetAdvTradePublicMarketTradesRequest,
-  GetAdvTradePublicProductCandlesRequest,
-  GetAdvTradePublicProductsRequest,
-  GetAdvTradeTransactionSummaryRequest,
-  MoveAdvTradePortfolioFundsRequest,
-  PreviewAdvTradeOrderRequest,
-  SubmitAdvTradeConvertQuoteRequest,
-  SubmitAdvTradeOrderRequest,
-} from './types/request/advanced-trade-client.js';
-import {
-  AdvTradeAccount,
-  AdvTradeAccountsList,
-  AdvTradeApiKeyPermissions,
-  AdvTradeCancelOrdersResponse,
-  AdvTradeCandle,
-  AdvTradeClosePositionResponse,
-  AdvTradeCurrentMarginWindow,
-  AdvTradeEditOrderPreviewResponse,
-  AdvTradeEditOrderResponse,
-  AdvTradeFill,
-  AdvTradeFuturesBalance,
-  AdvTradeFuturesPosition,
-  AdvTradeFuturesSweep,
-  AdvTradeMarketTrades,
-  AdvTradeOrder,
-  AdvTradeOrderPreview,
-  AdvTradePaymentMethod,
-  AdvTradePerpetualsPortfolio,
-  AdvTradePerpetualsPosition,
-  AdvTradePerpetualsPositionSummary,
-  AdvTradePortfolio,
-  AdvTradePortfolioBalance,
-  AdvTradePortfolioBreakdown,
-  AdvTradePricebook,
-  AdvTradeProduct,
-  AdvTradePublicProduct,
-  AdvTradeSubmitOrderResponse,
-  AdvTradeTransactionSummary,
-} from './types/response/advanced-trade-client.js';
-⋮----
-/**
- * REST client for Coinbase's Advanced Trade API:
- * https://docs.cdp.coinbase.com/advanced-trade/docs/api-overview/
- */
-export class CBAdvancedTradeClient extends BaseRestClient
-⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
-⋮----
-/**
-   *
-   * Custom SDK functions
-   *
-   */
-⋮----
-/**
-   * This method is used to get the latency and time sync between the client and the server.
-   * This is not official API endpoint and is only used for internal testing purposes.
-   * Use this method to check the latency and time sync between the client and the server.
-   * Final values might vary slightly, but it should be within few ms difference.
-   * If you have any suggestions or improvements to this measurement, please create an issue or pull request on GitHub.
-   */
-async fetchLatencySummary(): Promise<any>
-⋮----
-// Adjust server time by adding estimated one-way latency
-⋮----
-// Calculate time difference between adjusted server time and local time
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   *
-   * Account Endpoints
-   *
-   */
-⋮----
-/**
-   * List Accounts
-   *
-   * Get a list of authenticated accounts for the current user.
-   */
-getAccounts(params?: {
-    limit?: number;
-    cursor?: string;
-    retail_portfolio_id?: string; // deprecated
-}): Promise<AdvTradeAccountsList>
-⋮----
-retail_portfolio_id?: string; // deprecated
-⋮----
-/**
-   * Get Account
-   *
-   * Get a list of information about single account, given an account UUID.
-   * Tip: Use List Accounts (getAccounts funcion) to find account UUIDs.
-   */
-getAccount(params:
-⋮----
-/**
-   *
-   * Products Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Best Bid/Ask
-   *
-   * Get the best bid/ask for all products. A subset of all products can be returned instead by using the product_ids input.
-   */
-getBestBidAsk(params?:
-⋮----
-/**
-   * Get Product Book
-   *
-   * Get a list of bids/asks for a single product. The amount of detail shown can be customized with the limit parameter.
-   */
-getProductBook(params: {
-    product_id: string;
-    limit?: number;
-    aggregation_price_increment?: string;
-}): Promise<
-⋮----
-/**
-   * List Products
-   *
-   * Get a list of the available currency pairs for trading.
-   *
-   */
-getProducts(params?: GetAdvTradeProductsRequest): Promise<
-⋮----
-/**
-   * Get Product
-   *
-   * Get information on a single product by product ID.
-   */
-getProduct(params: {
-    product_id: string;
-    get_tradability_status?: boolean;
-}): Promise<AdvTradeProduct>
-⋮----
-/**
-   * Get Product Candles
-   *
-   * Get rates for a single product by product ID, grouped in buckets.
-   */
-getProductCandles(params: GetAdvTradeProductCandlesRequest): Promise<
-⋮----
-/**
-   * Get Market Trades
-   *
-   * Get snapshot information by product ID about the last trades (ticks) and best bid/ask.
-   */
-getMarketTrades(
-    params: GetAdvTradeMarketTradesRequest,
-): Promise<AdvTradeMarketTrades>
-⋮----
-/**
-   *
-   * Orders Endpoints
-   *
-   */
-⋮----
-/**
-   * Create Order
-   *
-   * Create an order with a specified product_id (asset-pair), side (buy/sell), etc.
-   *
-   */
-submitOrder(
-    params: SubmitAdvTradeOrderRequest,
-): Promise<AdvTradeSubmitOrderResponse>
-⋮----
-/**
-   * Cancel Orders
-   *
-   * Initiate cancel requests for one or more orders.
-   * The maximum number of order_ids that can be cancelled per request is 100.
-   * This number may be subject to change in emergency, but if a request exceeds the max,
-   * then an InvalidArgument error code will be returned with an error message denoting the limit.
-   */
-cancelOrders(params: {
-    order_ids: string[];
-}): Promise<AdvTradeCancelOrdersResponse>
-⋮----
-/**
-   * Edit Order
-   *
-   * Edit an order with a specified new size, or new price.
-   *
-   * - Your request moves to the back of the queue if you increase the size or increase or decrease the price.
-   * - If you decrease the size, you keep your place in line.
-   * - A client can only send an Edit Order request after the previous request for the same order has been fully processed.
-   */
-updateOrder(
-    params: EditAdvTradeOrderRequest,
-): Promise<AdvTradeEditOrderResponse>
-⋮----
-/**
-   * Edit Order Preview
-   *
-   * Preview an edit order request with a specified new size, or new price.
-   *
-   */
-updateOrderPreview(
-    params: EditAdvTradeOrderRequest,
-): Promise<AdvTradeEditOrderPreviewResponse>
-⋮----
-/**
-   * List Orders
-   *
-   * Get a list of orders filtered by optional query parameters.
-   *
-   * - The maximum number of OPEN orders returned is 1000.
-   * - The parameters start_date and end_date don't apply to open orders.
-   * - You cannot pair open orders with other order types.
-   * - You cannot query for OPEN orders with other order types.
-   */
-getOrders(params?: GetAdvTradeOrdersRequest): Promise<
-⋮----
-/**
-   * List Fills
-   *
-   * Get a list of fills filtered by optional query parameters (product_id, order_id, etc).
-   *
-   */
-getFills(params?: GetAdvTradeFillsRequest): Promise<
-⋮----
-/**
-   * Get Order
-   *
-   * Get a single order by order ID.
-   */
-getOrder(params: {
-    order_id: string;
-    client_order_id?: string;
-    user_native_currency?: string;
-}): Promise<
-⋮----
-/**
-   * Preview Order
-   *
-   * Preview an order.
-   *
-   */
-previewOrder(
-    params: PreviewAdvTradeOrderRequest,
-): Promise<AdvTradeOrderPreview>
-⋮----
-/**
-   * Close Position
-   *
-   * Places an order to close any open positions for a specified product_id.
-   *
-   */
-closePosition(
-    params: CloseAdvTradePositionRequest,
-): Promise<AdvTradeClosePositionResponse>
-⋮----
-/**
-   *
-   * Portfolios Endpoints
-   *
-   */
-⋮----
-/**
-   * List Portfolios
-   *
-   * Get all portfolios of a user.
-   */
-getPortfolios(params?: {
-    portfolio_type?: 'UNDEFINED' | 'DEFAULT' | 'CONSUMER' | 'INTX';
-}): Promise<
-⋮----
-/**
-   * Create Portfolio
-   *
-   * Create a portfolio.
-   */
-createPortfolio(params:
-⋮----
-/**
-   * Move Portfolio Funds
-   *
-   * Move funds between portfolios.
-   */
-movePortfolioFunds(params: MoveAdvTradePortfolioFundsRequest): Promise<
-⋮----
-/**
-   * Get Portfolio Breakdown
-   *
-   * Get the breakdown of a portfolio.
-   */
-getPortfolioBreakdown(params: {
-    portfolio_uuid: string;
-    currency?: string;
-}): Promise<
-⋮----
-/**
-   * Delete Portfolio
-   *
-   * Delete a portfolio.
-   */
-deletePortfolio(params:
-⋮----
-/**
-   * Edit Portfolio
-   *
-   * Edit a portfolio.
-   *
-   */
-updatePortfolio(params: {
-    portfolio_uuid: string;
-    name: string;
-}): Promise<
-⋮----
-/**
-   *
-   * Futures Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Futures Balance Summary
-   *
-   * Get a summary of balances for CFM trading.
-   *
-   * Futures vs Spot Accounts:
-   * - Futures and spot balances are held in different accounts.
-   * - Cash is always deposited into your Coinbase Inc. (CBI) spot account.
-   * - Cash is automatically transferred to your Coinbase Financial Markets (CFM) futures account to satisfy margin requirements.
-   * - You can transfer cash that isn't being used to margin or maintain futures positions into your CBI spot account.
-   * - Funds held in a CBI spot account do not receive the preferential treatment given to funds held in a regulated futures account.
-   *
-   * Intraday vs. Overnight Margin Health:
-   * - If you are opted in to receive increased leverage on futures trades during the intraday window (from 8am-4pm ET), this endpoint will return your intraday and overnight margin health.
-   */
-getFuturesBalanceSummary(): Promise<
-⋮----
-/**
-   * Get Intraday Margin Setting
-   *
-   * Get the futures intraday margin setting.
-   */
-getIntradayMarginSetting(): Promise<
-⋮----
-/**
-   * Set Intraday Margin Setting
-   *
-   * Set the futures intraday margin setting.
-   */
-setIntradayMarginSetting(params?: {
-    setting?:
-      | 'INTRADAY_MARGIN_SETTING_UNSPECIFIED'
-      | 'INTRADAY_MARGIN_SETTING_STANDARD'
-      | 'INTRADAY_MARGIN_SETTING_INTRADAY';
-}): Promise<any>
-⋮----
-/**
-   * Get Current Margin Window
-   *
-   * Get the futures current margin window.
-   */
-getCurrentMarginWindow(params?: {
-    margin_profile_type?:
-      | 'MARGIN_PROFILE_TYPE_UNSPECIFIED'
-      | 'MARGIN_PROFILE_TYPE_RETAIL_REGULAR'
-      | 'MARGIN_PROFILE_TYPE_RETAIL_INTRADAY_MARGIN_1';
-}): Promise<AdvTradeCurrentMarginWindow>
-⋮----
-/**
-   * List Futures Positions
-   *
-   * Get a list of positions in CFM products.
-   */
-getFuturesPositions(): Promise<
-⋮----
-/**
-   * Get Futures Position
-   *
-   * Get positions for a specific CFM product.
-   */
-getFuturesPosition(params: {
-    product_id: string;
-}): Promise<
-⋮----
-/**
-   * Schedule Futures Sweep
-   *
-   * Schedules a sweep of funds from FCM wallet to USD Spot wallet.
-   *
-   * Futures Sweep Processing:
-   * - Sweep requests submitted before 5PM ET each day are processed the following business day.
-   * - Sweep requests submitted after 5PM ET each day are processed in 2 business days.
-   * - You can have at most one pending sweep request at a time.
-   *
-   * Market movements related to your open positions may impact the final amount that is transferred into your spot account.
-   * The final funds transferred, up to your specified amount, depend on the available excess in your futures account.
-   */
-scheduleFuturesSweep(params?: {
-    usd_amount?: string;
-}): Promise<
-⋮----
-/**
-   * List Futures Sweeps
-   *
-   * Get pending and processing sweeps of funds from FCM wallet to USD Spot wallet.
-   *
-   * Pending vs. Processing Sweeps:
-   * - A pending sweep is a sweep that has not started processing and can be cancelled.
-   * - A processing sweep is a sweep that is currently being processed and cannot be cancelled.
-   * - Once a sweep is complete, it no longer appears in the list of sweeps.
-   */
-getFuturesSweeps(): Promise<
-⋮----
-/**
-   * Cancel Pending Futures Sweep
-   *
-   * Cancel the pending sweep of funds from FCM wallet to USD Spot wallet.
-   */
-cancelPendingFuturesSweep(): Promise<
-⋮----
-/**
-   *
-   * Perpetuals Endpoints
-   *
-   */
-⋮----
-/**
-   * Allocate Portfolio
-   *
-   * Allocate portfolio funds to a sub-portfolio on Intx Portfolio.
-   *
-   */
-allocatePortfolio(params: AllocateAdvTradePortfolioRequest): Promise<any>
-⋮----
-/**
-   * Get Perpetuals Portfolio Summary
-   *
-   * Get a summary of your Perpetuals portfolio.
-   */
-getPerpetualsPortfolioSummary(params: {
-    portfolio_uuid: string;
-}): Promise<AdvTradePerpetualsPortfolio>
-⋮----
-/**
-   * List Perpetuals Positions
-   *
-   * Get a list of open positions in your Perpetuals portfolio.
-   */
-getPerpetualsPositions(params: {
-    portfolio_uuid: string;
-}): Promise<AdvTradePerpetualsPositionSummary>
-⋮----
-/**
-   * Get Perpetuals Position
-   *
-   * Get a specific open position on Intx.
-   *
-   */
-getPerpetualsPosition(params: {
-    portfolio_uuid: string;
-    symbol: string;
-}): Promise<
-⋮----
-/**
-   * Get Portfolios Balances
-   *
-   * Get a list of asset balances on Intx for a given Portfolio.
-   */
-getPortfoliosBalances(params:
-⋮----
-/**
-   * Opt In or Out of Multi Asset Collateral
-   *
-   * Enable or Disable Multi Asset Collateral for a given Portfolio.
-   */
-updateMultiAssetCollateral(params?: {
-    portfolio_uuid?: string;
-    multi_asset_collateral_enabled?: boolean;
-}): Promise<
-⋮----
-/**
-   *
-   * Fees Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Transaction Summary
-   *
-   * Get a summary of transactions with fee tiers, total volume, and fees.
-   */
-getTransactionSummary(
-    params?: GetAdvTradeTransactionSummaryRequest,
-): Promise<AdvTradeTransactionSummary>
-⋮----
-/**
-   *
-   * Converts Endpoints
-   *
-   */
-⋮----
-/**
-   * Create Convert Quote
-   *
-   * Create a convert quote with a specified source account, target account, and amount.
-   * Convert is applicable for USDC-USD and EURC-EUR conversion.
-   */
-submitConvertQuote(params: SubmitAdvTradeConvertQuoteRequest): Promise<any>
-⋮----
-/**
-   * Get Convert Trade
-   *
-   * Gets a list of information about a convert trade with a specified trade id, source account, and target account.
-   */
-getConvertTrade(params: {
-    trade_id: string;
-    from_account: string;
-    to_account: string;
-}): Promise<any>
-⋮----
-/**
-   * Commit Convert Trade
-   *
-   * Commits a convert trade with a specified trade id, source account, and target account.
-   */
-commitConvertTrade(params: {
-    trade_id: string;
-    from_account: string;
-    to_account: string;
-}): Promise<any>
-⋮----
-/**
-   *
-   * Public Endpoints
-   *
-   */
-⋮----
-getServerTime(): Promise<
-⋮----
-/**
-   * Get Public Product Book
-   *
-   * Get a list of bids/asks for a single product. The amount of detail shown can be customized with the limit parameter.
-   */
-getPublicProductBook(params: {
-    product_id: string;
-    limit?: number;
-    aggregation_price_increment?: string;
-}): Promise<
-⋮----
-/**
-   * List Public Products
-   *
-   * Get a list of the available currency pairs for trading.
-   */
-getPublicProducts(params?: GetAdvTradePublicProductsRequest): Promise<
-⋮----
-/**
-   * Get Public Product
-   *
-   * Get information on a single product by product ID.
-   */
-getPublicProduct(params: {
-    product_id: string;
-}): Promise<AdvTradePublicProduct>
-⋮----
-/**
-   * Get Public Product Candles
-   *
-   * Get rates for a single product by product ID, grouped in buckets.
-   */
-getPublicProductCandles(
-    params: GetAdvTradePublicProductCandlesRequest,
-): Promise<
-⋮----
-/**
-   * Get Public Market Trades
-   *
-   * Get snapshot information by product ID about the last trades (ticks) and best bid/ask.
-   */
-getPublicMarketTrades(
-    params: GetAdvTradePublicMarketTradesRequest,
-): Promise<AdvTradeMarketTrades>
-⋮----
-/**
-   *
-   * Payment Methods Endpoints
-   *
-   */
-⋮----
-/**
-   * List Payment Methods
-   *
-   * Get a list of payment methods for the current user.
-   */
-getPaymentMethods(): Promise<
-⋮----
-/**
-   * Get Payment Method
-   *
-   * Get information about a payment method for the current user.
-   */
-getPaymentMethod(params:
-⋮----
-/**
-   *
-   * Data API Endpoints
-   *
-   */
-⋮----
-/**
-   * Get API Key Permissions
-   *
-   * Get information about your CDP API key permissions.
-   */
-getApiKeyPermissions(): Promise<AdvTradeApiKeyPermissions>
-
-================
-File: src/CBAppClient.ts
-================
-import { AxiosRequestConfig } from 'axios';
-⋮----
-import { BaseRestClient } from './lib/BaseRestClient.js';
-import {
-  getParamsFromURL,
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-} from './lib/requestUtils.js';
-import {
-  CBAppDepositFundsRequest,
-  CBAppSendMoneyRequest,
-  CBAppTransferMoneyRequest,
-  CBAppWithdrawFundsRequest,
-} from './types/request/coinbase-app-client.js';
-import {
-  CBAppAccount,
-  CBAppAddress,
-  CBAppCryptocurrency,
-  CBAppDepositWithdrawal,
-  CBAppFiatCurrency,
-  CBAppPagination,
-  CBAppTransaction,
-  CBAppTransfer,
-} from './types/response/coinbase-app-client.js';
-⋮----
-/**
- * REST client for Coinbase's Coinbase App API:
- * https://docs.cdp.coinbase.com/coinbase-app/docs/welcome
- */
-export class CBAppClient extends BaseRestClient
-⋮----
-constructor(
-    restClientOptions: RestClientOptions = {},
-    requestOptions: AxiosRequestConfig = {},
-)
-⋮----
-// Some endpoints return a warning if a version header isn't included: https://docs.cdp.coinbase.com/coinbase-app/docs/versioning
-// Currently set to a date from the changelog: https://docs.cdp.coinbase.com/coinbase-app/docs/changelog
-⋮----
-getClientType(): RestClientType
-⋮----
-/**
-   *
-   * Account Endpoints
-   *
-   */
-⋮----
-/**
-   * List Accounts
-   *
-   * List a current user's accounts to which the authentication method has access to.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of accounts.
-   */
-getAccounts(params?: {
-    paginationURL?: string;
-    starting_after?: string;
-}): Promise<
-⋮----
-/**
-   * Show Account
-   *
-   * Get a current user's account by account ID or currency string.
-   */
-getAccount(params:
-⋮----
-/**
-   *
-   * Address Endpoints
-   *
-   */
-⋮----
-/**
-   * Create Address
-   *
-   * Creates a new address for an account. Addresses can be created for wallet account types.
-   */
-createAddress(params:
-⋮----
-/**
-   * List Addresses
-   *
-   * Lists addresses for an account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of addresses.
-   */
-getAddresses(params: {
-    account_id: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   * Show Address
-   *
-   * Get an single address for an account.
-   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
-   *
-   * !! An address can only be associated with one account. See Create Address to create new addresses.
-   */
-getAddress(params:
-⋮----
-/**
-   * List Address Transactions
-   *
-   * List transactions that have been sent to a specific address.
-   * A regular cryptocurrency address can be used in place of address_id but the address must be associated with the correct account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
-   */
-getAddressTransactions(params: {
-    account_id: string;
-    addressId: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   *
-   * Transactions Endpoints
-   *
-   */
-⋮----
-/**
-   * Send Money
-   *
-   * Send funds to a network address for any Coinbase supported asset, or email address of the recipient.
-   * No transaction fees are required for off-blockchain cryptocurrency transactions.
-   *
-   * TRAVEL RULE DATA GUIDE: https://docs.cdp.coinbase.com/coinbase-app/docs/coinbase-app-travel-rule
-   */
-sendMoney(
-    params: CBAppSendMoneyRequest,
-): Promise<
-⋮----
-/**
-   * Transfer Money
-   *
-   * Transfer any Coinbase supported digital asset between two of a single user's accounts.
-   * Accounts must support the same currency for transfers to be successful.
-   */
-transferMoney(
-    params: CBAppTransferMoneyRequest,
-): Promise<
-⋮----
-/**
-   * List Transactions
-   *
-   * Lists the transactions of an account by account ID.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of transactions.
-   */
-getTransactions(params: {
-    account_id: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   * Show Transaction
-   *
-   * Get a single transaction for an account.
-   */
-getTransaction(params: {
-    account_id: string;
-    transactionId: string;
-}): Promise<
-⋮----
-/**
-   *
-   * Deposits Endpoints
-   *
-   */
-⋮----
-/**
-   * Deposit Funds
-   *
-   * Deposits user-defined amount of funds to a fiat account.
-   */
-depositFunds(params: CBAppDepositFundsRequest): Promise<CBAppTransfer>
-⋮----
-/**
-   * Commit Deposit
-   *
-   * Completes a deposit that is created in commit: false state.
-   */
-commitDeposit(params: {
-    account_id: string;
-    deposit_id: string;
-}): Promise<CBAppTransfer>
-⋮----
-/**
-   * List Deposits
-   *
-   * Lists fiat deposits for an account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of deposits.
-   */
-getDeposits(params:
-⋮----
-/**
-   * Show Deposit
-   *
-   * Get one deposit by deposit Id.
-   */
-getDeposit(params:
-⋮----
-/**
-   *
-   * Withdrawals Endpoints
-   *
-   */
-⋮----
-/**
-   * Withdraw Funds
-   *
-   * Withdraws a user-defined amount of funds from a fiat account.
-   */
-withdrawFunds(params: CBAppWithdrawFundsRequest): Promise<CBAppTransfer>
-⋮----
-/**
-   * Commit Withdrawal
-   *
-   * Completes a withdrawal that is created in commit: false state.
-   */
-commitWithdrawal(params: {
-    account_id: string;
-    withdrawal_id: string;
-}): Promise<CBAppTransfer>
-⋮----
-/**
-   * List Withdrawals
-   *
-   * Lists withdrawals for an account.
-   *
-   * This endpoint is paginated. In case you are calling it first time, leave paginationURL empty.
-   * If you are paginating, provide the paginationURL value from the previous response and you will receive the next page of withdrawals.
-   */
-getWithdrawals(params: {
-    account_id: string;
-    paginationURL?: string;
-}): Promise<
-⋮----
-/**
-   * Show Withdrawal
-   *
-   * Get a single withdrawal.
-   */
-getWithdrawal(params: {
-    account_id: string;
-    withdrawal_id: string;
-}): Promise<
-⋮----
-/**
-   *
-   * DATA - Currencies Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Fiat Currencies
-   *
-   * Lists known fiat currencies. Currency codes conform to the ISO 4217 standard where possible.
-   * Currencies with no representation in ISO 4217 may use a custom code.
-   */
-getFiatCurrencies(): Promise<
-⋮----
-/**
-   * Get Cryptocurrencies
-   *
-   * Lists known cryptocurrencies.
-   */
-getCryptocurrencies(): Promise<CBAppCryptocurrency[]>
-⋮----
-/**
-   *
-   * DATA- Exchange rates Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Exchange Rates
-   *
-   * Get current exchange rates. Default base currency is USD but it can be defined as any supported currency.
-   * Returned rates will define the exchange rate for one unit of the base currency.
-   */
-getExchangeRates(params?:
-⋮----
-/**
-   *
-   * DATA - Prices Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Buy Price
-   *
-   * Get the total price to buy one bitcoin or ether.
-   * This endpoint doesn't require authentication.
-   */
-getBuyPrice(params:
-⋮----
-/**
-   * Get Sell Price
-   *
-   * Get the total price to sell one bitcoin or ether.
-   * This endpoint doesn't require authentication.
-   */
-getSellPrice(params:
-⋮----
-/**
-   * Get Spot Price
-   *
-   * Get the current market price for bitcoin. This is usually somewhere in between the buy and sell price.
-   * This endpoint doesn't require authentication.
-   */
-getSpotPrice(params:
-⋮----
-/**
-   *
-   * DATA - Time Endpoints
-   *
-   */
-⋮----
-/**
-   * Get Current Time
-   *
-   * Get the API server time.
-   * This endpoint doesn't require authentication.
-   */
-getCurrentTime(): Promise<
-
-================
-File: webpack/webpack.config.cjs
-================
-function generateConfig(name)
-⋮----
-// Add '.ts' and '.tsx' as resolvable extensions.
-⋮----
-// Node.js core modules not available in browsers
-// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
-⋮----
-// Code is already transpiled from TypeScript, no additional loaders needed
-
-================
-File: .nvmrc
-================
-v22.17.1
-
-================
-File: jest.config.ts
-================
-/**
- * For a detailed explanation regarding each configuration property, visit:
- * https://jestjs.io/docs/configuration
- */
-⋮----
-import type { Config } from 'jest';
-⋮----
-// All imported modules in your tests should be mocked automatically
-// automock: false,
-⋮----
-// Stop running tests after `n` failures
-// bail: 0,
-bail: false, // enable to stop test when an error occur,
-⋮----
-// The directory where Jest should store its cached dependency information
-// cacheDirectory: "/private/var/folders/kf/2k3sz4px6c9cbyzj1h_b192h0000gn/T/jest_dx",
-⋮----
-// Automatically clear mock calls, instances, contexts and results before every test
-⋮----
-// Indicates whether the coverage information should be collected while executing the test
-⋮----
-// An array of glob patterns indicating a set of files for which coverage information should be collected
-⋮----
-// The directory where Jest should output its coverage files
-⋮----
-// An array of regexp pattern strings used to skip coverage collection
-// coveragePathIgnorePatterns: [
-//   "/node_modules/"
-// ],
-⋮----
-// Indicates which provider should be used to instrument code for coverage
-⋮----
-// A list of reporter names that Jest uses when writing coverage reports
-// coverageReporters: [
-//   "json",
-//   "text",
-//   "lcov",
-//   "clover"
-// ],
-⋮----
-// An object that configures minimum threshold enforcement for coverage results
-// coverageThreshold: undefined,
-⋮----
-// A path to a custom dependency extractor
-// dependencyExtractor: undefined,
-⋮----
-// Make calling deprecated APIs throw helpful error messages
-// errorOnDeprecated: false,
-⋮----
-// The default configuration for fake timers
-// fakeTimers: {
-//   "enableGlobally": false
-// },
-⋮----
-// Force coverage collection from ignored files using an array of glob patterns
-// forceCoverageMatch: [],
-⋮----
-// A path to a module which exports an async function that is triggered once before all test suites
-// globalSetup: undefined,
-⋮----
-// A path to a module which exports an async function that is triggered once after all test suites
-// globalTeardown: undefined,
-⋮----
-// A set of global variables that need to be available in all test environments
-// globals: {},
-⋮----
-// The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-// maxWorkers: "50%",
-⋮----
-// An array of directory names to be searched recursively up from the requiring module's location
-// moduleDirectories: [
-//   "node_modules"
-// ],
-⋮----
-// An array of file extensions your modules use
-⋮----
-// modulePaths: ['src'],
-⋮----
-// A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-// moduleNameMapper: {},
-⋮----
-// An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-// modulePathIgnorePatterns: [],
-⋮----
-// Activates notifications for test results
-// notify: false,
-⋮----
-// An enum that specifies notification mode. Requires { notify: true }
-// notifyMode: "failure-change",
-⋮----
-// A preset that is used as a base for Jest's configuration
-// preset: undefined,
-⋮----
-// Run tests from one or more projects
-// projects: undefined,
-⋮----
-// Use this configuration option to add custom reporters to Jest
-// reporters: undefined,
-⋮----
-// Automatically reset mock state before every test
-// resetMocks: false,
-⋮----
-// Reset the module registry before running each individual test
-// resetModules: false,
-⋮----
-// A path to a custom resolver
-// resolver: undefined,
-⋮----
-// Automatically restore mock state and implementation before every test
-// restoreMocks: false,
-⋮----
-// The root directory that Jest should scan for tests and modules within
-// rootDir: undefined,
-⋮----
-// A list of paths to directories that Jest should use to search for files in
-// roots: [
-//   "<rootDir>"
-// ],
-⋮----
-// Allows you to use a custom runner instead of Jest's default test runner
-// runner: "jest-runner",
-⋮----
-// The paths to modules that run some code to configure or set up the testing environment before each test
-// setupFiles: [],
-⋮----
-// A list of paths to modules that run some code to configure or set up the testing framework before each test
-// setupFilesAfterEnv: [],
-⋮----
-// The number of seconds after which a test is considered as slow and reported as such in the results.
-// slowTestThreshold: 5,
-⋮----
-// A list of paths to snapshot serializer modules Jest should use for snapshot testing
-// snapshotSerializers: [],
-⋮----
-// The test environment that will be used for testing
-// testEnvironment: "jest-environment-node",
-⋮----
-// Options that will be passed to the testEnvironment
-// testEnvironmentOptions: {},
-⋮----
-// Adds a location field to test results
-// testLocationInResults: false,
-⋮----
-// The glob patterns Jest uses to detect test files
-⋮----
-// "**/__tests__/**/*.[jt]s?(x)",
-⋮----
-// An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-// testPathIgnorePatterns: [
-//   "/node_modules/"
-// ],
-⋮----
-// The regexp pattern or array of patterns that Jest uses to detect test files
-// testRegex: [],
-⋮----
-// This option allows the use of a custom results processor
-// testResultsProcessor: undefined,
-⋮----
-// This option allows use of a custom test runner
-// testRunner: "jest-circus/runner",
-⋮----
-// A map from regular expressions to paths to transformers
-// transform: undefined,
-⋮----
-// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-// transformIgnorePatterns: [
-//   "/node_modules/",
-//   "\\.pnp\\.[^\\/]+$"
-// ],
-⋮----
-// Prevents import esm module error from v1 axios release, issue #5026
-⋮----
-// An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
-// unmockedModulePathPatterns: undefined,
-⋮----
-// Indicates whether each individual test should be reported during the run
-// verbose: undefined,
-verbose: true, // report individual test
-⋮----
-// An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-// watchPathIgnorePatterns: [],
-⋮----
-// Whether to use watchman for file crawling
-// watchman: true,
-
-================
 File: LICENSE.md
 ================
 Copyright 2025 Tiago Siebler
@@ -8162,842 +8942,295 @@ File: tsconfig.json
 }
 
 ================
-File: examples/AdvancedTrade/WebSockets/privateWs.ts
+File: webpack/webpack.config.cjs
 ================
-import {
-  // DefaultLogger,
-  WebsocketClient,
-  // WS_KEY_MAP,
-  WsTopicRequest,
-} from '../../../src/index.js';
+function generateConfig(name)
 ⋮----
-// DefaultLogger,
+// Add '.ts' and '.tsx' as resolvable extensions.
 ⋮----
-// WS_KEY_MAP,
+// Node.js core modules not available in browsers
+// The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
 ⋮----
-/**
- * import { WebsocketClient } from 'coinbase-api';
- * const { WebsocketClient } = require('coinbase-api');
- */
-⋮----
-async function start()
-⋮----
-// key name & private key, as returned by coinbase when creating your API keys.
-// Note: the below example is a dummy key and won't actually work
-⋮----
-// Optional: fully customise the logging experience by injecting a custom logger
-// const logger: typeof DefaultLogger = {
-//   ...DefaultLogger,
-//   trace: (...params) => {
-//     if (
-//       [
-//         'Sending ping',
-//         'Sending upstream ws message: ',
-//         'Received pong, clearing pong timer',
-//         'Received ping, sending pong frame',
-//       ].includes(params[0])
-//     ) {
-//       return;
-//     }
-//     console.log('trace', params);
-//   },
-// };
-⋮----
-// Either pass the full JSON object that can be downloaded when creating your API keys
-// cdpApiKey: advancedTradeCdpAPIKey,
-⋮----
-// initialise the client
-/**
-       *
-       * You can add both ED25519 and ECDSA keys, client will recognize both types of keys
-       *
-       * ECDSA:
-       *
-       * {
-       *   apiKey: 'organizations/your_org_id/apiKeys/your_api_key_id',
-       *   apiSecret:
-       *     '-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIPT/TTZPxw0kDGvpuCENJp9A4/2INAt9/QKKfyidTWM8oAoGCCqGSM49\nAwEHoUQDQgAEd+cnxrKl536ly5eYBi+8dvXt1MJXYRo+/v38h9HrFKVGBRndU9DY\npV357xIfqeJEzb/MBuk3EW8cG9RTrYBwjg==\n-----END EC PRIVATE KEY-----\n',
-       * }
-       *
-       * ED25519:
-       * {
-       *   apiKey: 'your-api-key-id',
-       *   apiSecret: 'yourExampleApiSecretEd25519Version==',
-       * }
-       *
-       *
-       */
-⋮----
-// logger,
-⋮----
-// Data received
-⋮----
-// Something happened, attempting to reconenct
-⋮----
-// Reconnect successful
-⋮----
-// Connection closed. If unexpected, expect reconnect -> reconnected.
-⋮----
-// Reply to a request, e.g. "subscribe"/"unsubscribe"/"authenticate"
-⋮----
-// throw new Error('res?');
-⋮----
-/**
-     * Use the client subscribe(topic, market) pattern to subscribe to any websocket topic.
-     *
-     * You can subscribe to topics one at a time or many one one request.
-     *
-     * Topics can be sent as simple strings, if no parameters are required.
-     *
-     * Any subscribe requests on the "advTradeUserData" market are automatically authenticated with the available credentials
-     */
-// client.subscribe('heartbeats', 'advTradeUserData');
-⋮----
-// This is the same as above, but uses WS_KEY_MAP as an enum (do this if you're not sure what value to put)
-// client.subscribe('futures_balance_summary', WS_KEY_MAP.advTradeUserData);
-⋮----
-// Subscribe to the user feed for the advanced trade websocket
-⋮----
-// /**
-//  * Or, as an array of simple strings.
-//  *
-//  * Any requests sent to the "advTradeUserData" wsKey are
-//  * automatically authenticated, if API keys are avaiable:
-//  */
-// client.subscribe(
-//   ['futures_balance_summary', 'user'],
-//   'advTradeUserData',
-// );
-⋮----
-/**
-     * Or send a more structured object with parameters, e.g. if parameters are required
-     */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-⋮----
-/**
-       * Anything in the payload will be merged into the subscribe "request",
-       * allowing you to send misc parameters supported by the exchange (such as `product_ids: string[]`)
-       */
-⋮----
-// In this case, the "futures_balance_summary" channel doesn't support any parameters
-// product_ids: ['ETH-USD', 'BTC-USD'],
+// Code is already transpiled from TypeScript, no additional loaders needed
 
 ================
-File: src/lib/websocket/WsStore.ts
+File: .nvmrc
 ================
-import WebSocket from 'isomorphic-ws';
-⋮----
-import { DefaultLogger } from './logger.js';
-import {
-  DeferredPromise,
-  WSConnectedResult,
-  WsConnectionStateEnum,
-  WsStoredState,
-} from './WsStore.types.js';
-⋮----
-/**
- * Simple comparison of two objects, recursive for nested objects
- */
-export function isDeepObjectMatch(object1: unknown, object2: unknown): boolean
-⋮----
-type DeferredPromiseRef =
-  (typeof DEFERRED_PROMISE_REF)[keyof typeof DEFERRED_PROMISE_REF];
-⋮----
-export class WsStore<
-WsKey extends string,
-⋮----
-constructor(logger: typeof DefaultLogger)
-⋮----
-/** Get WS stored state for key, optionally create if missing */
-get(
-    key: WsKey,
-    createIfMissing?: true,
-  ): WsStoredState<TWSTopicSubscribeEventArgs>;
-⋮----
-get(
-    key: WsKey,
-    createIfMissing?: false,
-  ): WsStoredState<TWSTopicSubscribeEventArgs> | undefined;
-⋮----
-get(
-    key: WsKey,
-    createIfMissing?: boolean,
-): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
-⋮----
-getKeys(): WsKey[]
-⋮----
-create(key: WsKey): WsStoredState<TWSTopicSubscribeEventArgs> | undefined
-⋮----
-delete(key: WsKey): void
-⋮----
-// TODO: should we allow this at all? Perhaps block this from happening...
-⋮----
-/* connection websocket */
-⋮----
-hasExistingActiveConnection(key: WsKey): boolean
-⋮----
-getWs(key: WsKey): WebSocket | undefined
-⋮----
-setWs(key: WsKey, wsConnection: WebSocket): WebSocket
-⋮----
-getDeferredPromise<TSuccessResult = any>(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-): DeferredPromise<TSuccessResult> | undefined
-⋮----
-createDeferredPromise<TSuccessResult = any>(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    throwIfExists: boolean,
-): DeferredPromise<TSuccessResult>
-⋮----
-// console.log('existing promise');
-⋮----
-// console.log('create promise');
-⋮----
-// TODO: Once stable, use Promise.withResolvers in future
-⋮----
-resolveDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    value: unknown,
-    removeAfter: boolean,
-): void
-⋮----
-rejectDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-    value: unknown,
-    removeAfter: boolean,
-): void
-⋮----
-removeDeferredPromise(
-    wsKey: WsKey,
-    promiseRef: string | DeferredPromiseRef,
-): void
-⋮----
-// Just in case it's pending
-⋮----
-rejectAllDeferredPromises(wsKey: WsKey, reason: string): void
-⋮----
-// Skip reserved keys, such as the connection promise
-⋮----
-/** Get promise designed to track a connection attempt in progress. Resolves once connected. */
-getConnectionInProgressPromise(
-    wsKey: WsKey,
-): DeferredPromise<WSConnectedResult> | undefined
-⋮----
-/**
-   * Create a deferred promise designed to track a connection attempt in progress.
-   *
-   * Will throw if existing promise is found.
-   */
-createConnectionInProgressPromise(
-    wsKey: WsKey,
-    throwIfExists: boolean,
-): DeferredPromise<WSConnectedResult>
-⋮----
-/** Remove promise designed to track a connection attempt in progress */
-removeConnectingInProgressPromise(wsKey: WsKey): void
-⋮----
-/* connection state */
-⋮----
-isWsOpen(key: WsKey): boolean
-⋮----
-getConnectionState(key: WsKey): WsConnectionStateEnum
-⋮----
-setConnectionState(key: WsKey, state: WsConnectionStateEnum)
-⋮----
-// console.log(new Date(), `setConnectionState(${key}, ${state})`);
-⋮----
-isConnectionState(key: WsKey, state: WsConnectionStateEnum): boolean
-⋮----
-/**
-   * Check if we're currently in the process of opening a connection for any reason. Safer than only checking "CONNECTING" as the state
-   * @param key
-   * @returns
-   */
-isConnectionAttemptInProgress(key: WsKey): boolean
-⋮----
-/* subscribed topics */
-⋮----
-getTopics(key: WsKey): Set<TWSTopicSubscribeEventArgs>
-⋮----
-getTopicsByKey(): Record<string, Set<TWSTopicSubscribeEventArgs>>
-⋮----
-// Since topics are objects we can't rely on the set to detect duplicates
-/**
-   * Find matching "topic" request from the store
-   * @param key
-   * @param topic
-   * @returns
-   */
-getMatchingTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// if (typeof topic === 'string') {
-//   return this.getMatchingTopic(key, { channel: topic });
-// }
-⋮----
-addTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// console.log(`wsStore.addTopic(${key}, ${topic})`);
-// Check for duplicate topic. If already tracked, don't store this one
-⋮----
-deleteTopic(key: WsKey, topic: TWSTopicSubscribeEventArgs)
-⋮----
-// Check if we're subscribed to a topic like this
+v24.18.0
 
 ================
-File: src/lib/jwtNode.ts
+File: src/lib/BaseRestClient.ts
 ================
-import { createPrivateKey } from 'crypto';
-import { importPKCS8, SignJWT } from 'jose';
+import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
+// NOTE: https.Agent is Node.js-only and not available in browser environments
+// Browser builds (via webpack) exclude this module - see webpack.config.js fallback settings
+import https from 'https';
 import { nanoid } from 'nanoid';
 ⋮----
-interface JWTSignParams {
-  algorithm?: 'ES256' | 'EdDSA';
-  timestampMs: number;
-  jwtExpiresSeconds: number;
-  apiPubKey: string;
-  apiPrivKey: string;
-}
+import {
+  CloseAdvTradePositionRequest,
+  SubmitAdvTradeOrderRequest,
+} from '../types/request/advanced-trade-client.js';
+import { SubmitCBExchOrderRequest } from '../types/request/coinbase-exchange.js';
+import { SubmitINTXOrderRequest } from '../types/request/coinbase-international.js';
+import { SubmitPrimeOrderRequest } from '../types/request/coinbase-prime.js';
+import { CustomOrderIdProperty } from '../types/shared.types.js';
+import { signJWT } from './jwtNode.js';
+import { neverGuard } from './misc-util.js';
+import {
+  APIIDPrefix,
+  getRestBaseUrl,
+  logInvalidOrderId,
+  REST_CLIENT_TYPE_ENUM,
+  RestClientOptions,
+  RestClientType,
+  serializeParams,
+} from './requestUtils.js';
+import { signMessage } from './webCryptoAPI.js';
 ⋮----
-interface KeyInfo {
-  algorithm: 'ES256' | 'EdDSA';
-  privateKey: string;
-}
-⋮----
-/**
- * Auto-detect key type and format based on the private key content
- */
-function detectKeyTypeAndFormat(privateKeyPem: string): KeyInfo
-⋮----
-// ECDSA key detection (PEM format)
-⋮----
-// Ed25519 key detection (base64 string without PEM headers)
-// Ed25519 private keys from Coinbase are provided as base64-encoded PKCS#8 keys
-⋮----
-// Try to decode as base64 to validate it's a valid base64 string
-⋮----
-// Ed25519 PKCS#8 keys are typically 48 bytes (44 bytes + padding)
-// Raw Ed25519 keys are 32 bytes, but Coinbase provides PKCS#8 encoded keys
-⋮----
-// Convert base64 Ed25519 key to PEM format for jose
-⋮----
-// Not a valid base64 string, fall through
-⋮----
-// Default to ECDSA if we can't determine the type
-⋮----
-/**
- * Convert EC private key to PKCS#8 format if needed
- */
-function ensurePKCS8Format(privateKeyPem: string): string
-⋮----
-// Convert EC private key to PKCS#8 format
-⋮----
-/**
- * Convert base64 Ed25519 private key to PKCS#8 format
- */
-function convertEd25519ToPKCS8(base64Key: string): string
-⋮----
-// Handle different Ed25519 key formats
-⋮----
-// Raw 32-byte Ed25519 private key
-⋮----
-// libsodium format: 32 bytes private key + 32 bytes public key
-// Extract just the private key (first 32 bytes)
-⋮----
-// Already PKCS#8 encoded, convert to PEM
-⋮----
-// Validate the key
-⋮----
-// Create PKCS#8 DER encoding for Ed25519 private key
-// PKCS#8 structure for Ed25519:
-// SEQUENCE {
-//   INTEGER 0 (version)
-//   SEQUENCE {
-//     OBJECT IDENTIFIER 1.3.101.112 (Ed25519)
-//   }
-//   OCTET STRING {
-//     OCTET STRING privateKey (32 bytes)
-//   }
-// }
-⋮----
-const ed25519Oid = Buffer.from([0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70]); // Ed25519 OID
-⋮----
-Buffer.from([0x04, 0x22, 0x04, 0x20]), // OCTET STRING header + inner OCTET STRING header
-⋮----
-Buffer.from([0x30, 0x2e]), // SEQUENCE, total length 46 bytes
-Buffer.from([0x02, 0x01, 0x00]), // INTEGER 0 (version)
-ed25519Oid, // Algorithm identifier
-privateKeyOctetString, // Private key
-⋮----
-// Convert to PEM format
-⋮----
-// Validate the generated key
-⋮----
-export async function signJWT(
-  params: {
-    url: string;
-    method: string;
-  } & JWTSignParams,
-): Promise<string>
-⋮----
-// Remove https:// but keep the rest
-⋮----
-// Auto-detect key type and format, or use provided algorithm
-⋮----
-// Import the private key
-⋮----
-// Create and sign the JWT
-⋮----
-export async function signWSJWT(params: JWTSignParams): Promise<string>
-⋮----
-// Auto-detect key type and format, or use provided algorithm
-⋮----
-// Import the private key
-⋮----
-// Create and sign the JWT
-
-================
-File: src/types/websockets/client.ts
-================
-import type { ClientRequestArgs } from 'http';
-import WebSocket from 'isomorphic-ws';
-⋮----
-/** General configuration for the WebsocketClient */
-export interface WSClientConfigurableOptions {
-  /**
-   * Your API key name.
-   *
-   * - For the Advanced Trade or App APIs, this is your API Key Name.
-   */
-  apiKey?: string;
-
-  /**
-   * Your API key secret.
-   *
-   * - For the Advanced Trade or App APIs, this is your API private key (including the -----BEGIN EC PRIVATE KEY-----\n etc).
-   */
-  apiSecret?: string;
-
-  /**
-   * Your API passphrase (NOT your account password). Only used for the API groups that use an API passphrase:
-   * - Coinbase Exchange API
-   * - Coinbase International API
-   * - Coinbase Prime API
-   */
-  apiPassphrase?: string;
-
-  /**
-   * For JWT auth (adv trade & app API), seconds until jwt expires. Defaults to 120 seconds.
-   */
-  jwtExpiresSeconds?: number;
-
-  /** How often to check if the connection is alive */
-  pingInterval?: number;
-
-  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-  pongTimeout?: number;
-
-  /** Delay in milliseconds before respawning the connection */
-  reconnectTimeout?: number;
-
-  wsUrl?: string;
-
-  wsOptions?: {
-    protocols?: string[];
-    agent?: any;
-  } & Partial<WebSocket.ClientOptions | ClientRequestArgs>;
-
-  /**
-   * Connect to the sandbox for supported products
-   *
-   * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
-   * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
-   *
-   * - Coinbase App: No sandbox available.
-   * - Coinbase Advanced Trade: No sandbox available.
-   * - Coinbase Prime: No sandbox available.
-   */
-  useSandbox?: boolean;
-
-  /**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
-
-  /**
-   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
-   */
-  reauthWSAPIOnReconnect?: boolean;
-}
-⋮----
-/**
-   * Your API key name.
-   *
-   * - For the Advanced Trade or App APIs, this is your API Key Name.
-   */
-⋮----
-/**
-   * Your API key secret.
-   *
-   * - For the Advanced Trade or App APIs, this is your API private key (including the -----BEGIN EC PRIVATE KEY-----\n etc).
-   */
-⋮----
-/**
-   * Your API passphrase (NOT your account password). Only used for the API groups that use an API passphrase:
-   * - Coinbase Exchange API
-   * - Coinbase International API
-   * - Coinbase Prime API
-   */
-⋮----
-/**
-   * For JWT auth (adv trade & app API), seconds until jwt expires. Defaults to 120 seconds.
-   */
-⋮----
-/** How often to check if the connection is alive */
-⋮----
-/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
-⋮----
-/** Delay in milliseconds before respawning the connection */
-⋮----
-/**
-   * Connect to the sandbox for supported products
-   *
-   * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
-   * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
-   *
-   * - Coinbase App: No sandbox available.
-   * - Coinbase Advanced Trade: No sandbox available.
-   * - Coinbase Prime: No sandbox available.
-   */
-⋮----
-/**
-   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
-   *
-   * Look in the examples folder for a demonstration on using node's createHmac instead.
-   */
-⋮----
-/**
-   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
-   */
-⋮----
-/**
- * WS configuration that's always defined, regardless of user configuration
- * (usually comes from defaults if there's no user-provided values)
- */
-export interface WebsocketClientOptions extends WSClientConfigurableOptions {
-  pingInterval: number;
-  pongTimeout: number;
-  reconnectTimeout: number;
-  useSandbox: boolean;
+interface SignedRequest<T extends object | undefined = {}> {
+  originalParams: T;
+  paramsWithSign?: T & { sign: string };
+  serializedParams: string;
+  sign: string;
+  queryParamsWithSign: string;
+  timestamp: number;
   recvWindow: number;
-  /**
-   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
-   */
-  requireConnectionReadyConfirmation: boolean;
-  authPrivateConnectionsOnConnect: boolean;
-  authPrivateRequests: boolean;
-  reauthWSAPIOnReconnect: boolean;
+  headers: object;
 }
 ⋮----
-/**
-   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
-   */
+interface UnsignedRequest<T extends object | undefined = {}> {
+  originalParams: T;
+  paramsWithSign: T;
+}
 ⋮----
-export type WsMarket = 'advancedTrade' | 'exchange' | 'international' | 'prime';
-
-================
-File: .eslintrc.cjs
-================
-// 'no-unused-vars': ['warn'],
-
-================
-File: src/WebsocketClient.ts
-================
-import { BaseWebsocketClient, EmittableEvent } from './lib/BaseWSClient.js';
-import { signWSJWT } from './lib/jwtNode.js';
-import { neverGuard } from './lib/misc-util.js';
-import {
-  isCBAdvancedTradeErrorEvent,
-  isCBAdvancedTradeWSEvent,
-  isCBExchangeWSEvent,
-  isCBExchangeWSRequestOperation,
-  isCBINTXWSRequestOperation,
-  isCBPrimeWSRequestOperation,
-} from './lib/websocket/typeGuards.js';
-import {
-  getCBExchangeWSSign,
-  getCBInternationalWSSign,
-  getCBPrimeWSSign,
-  getMergedCBExchangeWSRequestOperations,
-  MessageEventLike,
-  WS_KEY_MAP,
-  WS_URL_MAP,
-  WsKey,
-  WsTopicRequest,
-} from './lib/websocket/websocket-util.js';
-import { WSConnectedResult } from './lib/websocket/WsStore.types.js';
-import { WsMarket } from './types/websockets/client.js';
-import {
-  WsAdvTradeRequestOperation,
-  WsExchangeAuthenticatedRequestOperation,
-  WsExchangeRequestOperation,
-  WsInternationalAuthenticatedRequestOperation,
-  WsInternationalRequestOperation,
-  WsOperation,
-  WsPrimeAuthenticatedRequestOperation,
-  WsPrimeRequestOperation,
-} from './types/websockets/requests.js';
-import {
-  WsAPITopicRequestParamMap,
-  WsAPITopicResponseMap,
-  WsAPIWsKeyTopicMap,
-} from './types/websockets/wsAPI.js';
+type SignMethod = 'coinbase';
 ⋮----
 /**
- * Any WS keys in this list will trigger automatic auth as required, if credentials are available
+ * Some requests require some params to be in the query string, some in the body, some even in the headers.
+ * This type anticipates either are possible in any combination.
+ *
+ * The request builder will automatically handle where parameters should go.
  */
+type ParamsInRequest = {
+  query?: object;
+  body?: object;
+  headers?: object;
+};
 ⋮----
-// Account data (fills), requires auth.
-⋮----
-// Coinbase Direct Market Data has direct access to Coinbase Exchange servers and requires auth.
-⋮----
-// The INTX feed always requires auth.
-⋮----
-// The Prime feed always requires auth.
+// request: {
+//   url: response.config.url,
+//   method: response.config.method,
+//   data: response.config.data,
+//   headers: response.config.headers,
+// },
 ⋮----
 /**
- * Any WS keys in this list will ALWAYS skip the authentication process, even if credentials are available
+ * Impure, mutates params to remove any values that have a key but are undefined.
  */
+function deleteUndefinedValues(params?: any): void
+⋮----
+export abstract class BaseRestClient
+⋮----
+/** Defines the client type (affecting how requests & signatures behave) */
+abstract getClientType(): RestClientType;
 ⋮----
 /**
- * WS topics are always a string for this exchange. Some exchanges use complex objects.
- */
-type WsTopic = string;
-⋮----
-export class WebsocketClient extends BaseWebsocketClient<WsKey>
-⋮----
-/**
-   * Request connection of all dependent (public & private) websockets, instead of waiting for automatic connection by library
+   * Create an instance of the REST client. Pass API credentials in the object in the first parameter.
+   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
+   * @param {AxiosRequestConfig} [networkOptions={}] HTTP networking options for axios
    */
-public connectAll(): Promise<(WSConnectedResult | undefined)[]>
-⋮----
-/**
-   * Request subscription to one or more topics. Pass topics as either an array of strings, or array of objects (if the topic has parameters).
-   * Objects should be formatted as {topic: string, params: object}.
-   *
-   * - Subscriptions are automatically routed to the correct websocket connection.
-   * - Authentication/connection is automatic.
-   * - Resubscribe after network issues is automatic.
-   *
-   * Call `unsubscribe(topics)` to remove topics
-   */
-public subscribe(
-    requests:
-      | (WsTopicRequest<WsTopic> | WsTopic)
-      | (WsTopicRequest<WsTopic> | WsTopic)[],
-    wsKey: WsKey,
+constructor(
+    restClientOptions: RestClientOptions = {},
+    networkOptions: AxiosRequestConfig = {},
 )
 ⋮----
+/** Throw errors if any request params are empty */
+⋮----
+/** in ms == 5 minutes by default */
+⋮----
+/** inject custom rquest options based on axios specs - see axios docs for more guidance on AxiosRequestConfig: https://github.com/axios/axios#request-config */
+⋮----
+// If enabled, configure a https agent with keepAlive enabled
+// NOTE: This is Node.js-only functionality. In browser environments, this code is skipped
+// as the 'https' module is excluded via webpack fallback configuration.
+// Browser connection pooling is handled automatically by the browser itself.
+⋮----
+// Extract existing https agent parameters, if provided, to prevent the keepAlive flag from overwriting an existing https agent completely
+⋮----
+// For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
+// parameter to define a custom httpsAgent with the desired properties
+⋮----
+// Newline escapes needed, if passed as env vars
+⋮----
+// Throw if one of these values is missing, and at least one of them is set
+⋮----
+// commerce only needs keys, not key and secret
+⋮----
 /**
-   * Unsubscribe from one or more topics. Similar to subscribe() but in reverse.
-   *
-   * - Requests are automatically routed to the correct websocket connection.
-   * - These topics will be removed from the topic cache, so they won't be subscribed to again.
+   * Timestamp used to sign the request. Override this method to implement your own timestamp/sync mechanism
    */
-public unsubscribe(
-    requests:
-      | (WsTopicRequest<WsTopic> | WsTopic)
-      | (WsTopicRequest<WsTopic> | WsTopic)[],
-    wsKey: WsKey,
+getSignTimestampMs(): number
+⋮----
+get(endpoint: string, params?: object)
+⋮----
+post(endpoint: string, params?: ParamsInRequest)
+⋮----
+getPrivate(endpoint: string, params?: object)
+⋮----
+postPrivate(endpoint: string, params?: ParamsInRequest)
+⋮----
+deletePrivate(endpoint: string, params?: ParamsInRequest)
+⋮----
+putPrivate(endpoint: string, params?: ParamsInRequest)
+⋮----
+patchPrivate(endpoint: string, params?: ParamsInRequest)
+⋮----
+/**
+   * @private Make a HTTP request to a specific endpoint. Private endpoint API calls are automatically signed.
+   */
+private async _call(
+    method: Method,
+    endpoint: string,
+    params?: ParamsInRequest,
+    isPublicApi?: boolean,
+): Promise<any>
+⋮----
+// Sanity check to make sure it's only ever prefixed by one forward slash
+⋮----
+// Build a request and handle signature process
+⋮----
+// Dispatch request
+⋮----
+// Throw if API returns an error (e.g. insufficient balance)
+⋮----
+public generateNewOrderId(): string
+⋮----
+/**
+   * Validate syntax meets requirements set by coinbase. Log warning if not.
+   */
+protected validateOrderId(
+    params:
+      | SubmitAdvTradeOrderRequest
+      | CloseAdvTradePositionRequest
+      | SubmitCBExchOrderRequest
+      | SubmitINTXOrderRequest
+      | SubmitPrimeOrderRequest,
+    orderIdProperty: CustomOrderIdProperty,
+): void
+⋮----
+// Not the cleanest but strict checks aren't quite necessary here either
+⋮----
+/**
+   * @private generic handler to parse request exceptions
+   */
+parseException(e: any, requestParams: any): unknown
+⋮----
+// Something happened in setting up the request that triggered an error
+⋮----
+// request made but no response received
+⋮----
+// The request was made and the server responded with a status code
+// that falls out of the range of 2xx
+⋮----
+// console.error('err: ', response?.data);
+⋮----
+// Prevent credentials from leaking into error messages
+⋮----
+/**
+   * @private sign request and set recv window
+   */
+private async signRequest<T extends ParamsInRequest | undefined = {}>(
+    data: T,
+    url: string,
+    endpoint: string,
+    method: Method,
+    signMethod: SignMethod,
+): Promise<SignedRequest<T>>
+⋮----
+// if there is body, use body - otherwise empty string
+⋮----
+// https://docs.cdp.coinbase.com/product-apis/docs/welcome
+⋮----
+// Both adv trade & app API use the same JWT auth mechanism
+// Advanced Trade: https://docs.cdp.coinbase.com/advanced-trade/docs/rest-api-auth
+// App: https://docs.cdp.coinbase.com/coinbase-app/docs/api-key-authentication
+⋮----
+// TODO: is there demand for oauth support?
+// Docs: https://docs.cdp.coinbase.com/coinbase-app/docs/coinbase-app-integration
+// See: https://github.com/tiagosiebler/coinbase-api/issues/24
+⋮----
+// Docs: https://docs.cdp.coinbase.com/exchange/docs/rest-auth
+⋮----
+const timestampInSeconds = timestampInMs / 1000; // decimals are OK
+⋮----
+// console.log('sign res: ', { signInput, ...headers });
+⋮----
+// For CB Exchange, is there demand for FIX
+// Docs, FIX: https://docs.cdp.coinbase.com/exchange/docs/fix-connectivity
+⋮----
+// Docs: https://docs.cdp.coinbase.com/intx/docs/rest-auth
+⋮----
+const timestampInSeconds = timestampInMs / 1000; // decimals are OK
+⋮----
+// For CB International, no query params are used in the signature
+⋮----
+// console.log('sign res: ', { signInput, ...headers });
+⋮----
+// For CB International, is there demand for FIX
+// Docs, FIX: https://docs.cdp.coinbase.com/intx/docs/fix-overview
+⋮----
+// Docs: https://docs.cdp.coinbase.com/prime/docs/rest-authentication
+⋮----
+const timestampInSeconds = Math.floor(timestampInMs / 1000); // decimal not allowed
+⋮----
+// For CB Prime, is there demand for FIX
+// Docs, FIX: https://docs.cdp.coinbase.com/prime/docs/fix-connectivity
+⋮----
+// https://docs.cdp.coinbase.com/commerce-onchain/docs/getting-started
+// No auth?
+⋮----
+private async prepareSignParams<TParams extends object | undefined>(
+    method: Method,
+    url: string,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: true,
+  ): Promise<UnsignedRequest<TParams>>;
+⋮----
+private async prepareSignParams<TParams extends object | undefined>(
+    method: Method,
+    url: string,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: false | undefined,
+  ): Promise<SignedRequest<TParams>>;
+⋮----
+private async prepareSignParams<TParams extends object | undefined>(
+    method: Method,
+    url: string,
+    endpoint: string,
+    signMethod: SignMethod,
+    params?: TParams,
+    isPublicApi?: boolean,
 )
 ⋮----
-/**
-   * Not supported by this exchange, do not use
-   */
+/** Returns an axios request object. Handles signing process automatically if this is a private API call */
+private async buildRequest(
+    method: Method,
+    endpoint: string,
+    url: string,
+    params?: any | undefined,
+    isPublicApi?: boolean,
+): Promise<AxiosRequestConfig>
 ⋮----
-// This overload allows the caller to omit the 3rd param, if it isn't required (e.g. for the login call)
-async sendWSAPIRequest<
-    TWSKey extends keyof WsAPIWsKeyTopicMap,
-    TWSChannel extends WsAPIWsKeyTopicMap[TWSKey] = WsAPIWsKeyTopicMap[TWSKey],
-    TWSParams extends
-      WsAPITopicRequestParamMap[TWSChannel] = WsAPITopicRequestParamMap[TWSChannel],
-    TWSAPIResponse extends
-      | WsAPITopicResponseMap[TWSChannel]
-      | object = WsAPITopicResponseMap[TWSChannel],
-  >(
-    wsKey: TWSKey,
-    channel: TWSChannel,
-    ...params: TWSParams extends undefined ? [] : [TWSParams]
-  ): Promise<TWSAPIResponse>;
+// request parameter headers for this request
 ⋮----
-async sendWSAPIRequest<
-    TWSKey extends keyof WsAPIWsKeyTopicMap = keyof WsAPIWsKeyTopicMap,
-    TWSChannel extends WsAPIWsKeyTopicMap[TWSKey] = WsAPIWsKeyTopicMap[TWSKey],
-    TWSParams extends
-      WsAPITopicRequestParamMap[TWSChannel] = WsAPITopicRequestParamMap[TWSChannel],
-  >(
-    wsKey: TWSKey,
-    channel: TWSChannel,
-    params?: TWSParams,
-): Promise<undefined>
+// auth headers for this request
 ⋮----
-/**
-   *
-   * Internal methods
-   *
-   */
-⋮----
-/**
-   * Return a websocket URL, which is connected to as-is.
-   * If a token or anything else is needed in the URL, this is a good place to add it.
-   */
-protected async getWsUrl(wsKey: WsKey): Promise<string>
-⋮----
-protected sendPingEvent(wsKey: WsKey)
-⋮----
-protected sendPongEvent(wsKey: WsKey)
-⋮----
-// Send a protocol layer pong
-⋮----
-protected isWsPing(msg: any): boolean
-⋮----
-protected isWsPong(msg: any): boolean
-⋮----
-// this.logger.info(`Not a pong: `, msg);
-⋮----
-protected resolveEmittableEvents(
-    wsKey: WsKey,
-    event: MessageEventLike,
-): EmittableEvent[]
-⋮----
-// E.g. {"type":"error","message":"rate limit exceeded","wsKey":"advTradeMarketData"}
-⋮----
-// Parse Advanced Trade WS events (update & response)
-⋮----
-// These are request/reply pattern events (e.g. after subscribing to topics or authenticating)
-⋮----
-// Generic data for a channel
-⋮----
-// Parse CB Exchange WS events
-⋮----
-// Generic data for a channel
-⋮----
-/**
-   * Determines if a topic is for a private channel, using a hardcoded list of strings
-   */
-protected isPrivateTopicRequest(
-    request: WsTopicRequest<string>,
-    wsKey: WsKey,
-): boolean
-⋮----
-protected getWsKeyForMarket(market: WsMarket, isPrivate: boolean): WsKey
-⋮----
-protected getWsMarketForWsKey(wsKey: WsKey): WsMarket
-⋮----
-protected getPrivateWSKeys(): WsKey[]
-⋮----
-/** Force subscription requests to be sent in smaller batches, if a number is returned */
-protected getMaxTopicsPerSubscribeEvent(wsKey: WsKey): number | null
-⋮----
-// Technically, INTX supports request batching but not with nested parameters, so we'll send one at a time
-⋮----
-// Exchange supports request batching, no known limit to max topics per request
-⋮----
-/**
-   * Map one or more topics into fully prepared "subscribe request" events (already stringified and ready to send)
-   */
-protected async getWsOperationEventsForTopics(
-    topicRequests: WsTopicRequest<string>[],
-    wsKey: WsKey,
-    operation: WsOperation,
-): Promise<string[]>
-⋮----
-/**
-     * Operations need to be structured in a way that this exchange understands.
-     * Parse the internal format into the format expected by the exchange. One request per operation.
-     */
-⋮----
-// In case there's ever more operation types than "subscribe" and "unsubscribe"
-⋮----
-// As of Sep 2024, parameters (such as product_id[]) cannot be nested with the channels array
-⋮----
-// This merges parametrs (such as product_id[]) into the top level request object
-⋮----
-/**
-     * - Merge commands into one if the exchange supports batch requests,
-     * - Apply auth/sign, if needed,
-     * - Apply any final formatting to return a string array, ready to be sent upstream.
-     */
-⋮----
-// Events that are ready to send (usually stringified JSON)
-// ADV trade only supports sending one at a time, so we don't try to merge them
-// These are already signed, if needed.
-⋮----
-/**
-           * No batching is supported for this product group, so we can already
-           * handle sign here and return it as is
-           */
-⋮----
-// Don't expect this to ever happen, but just to please typescript...
-⋮----
-// We're under the max topics per request limit.
-// Send operation requests as one merged request
-⋮----
-// We're over the max topics per request limit. Break into batches.
-⋮----
-// Don't expect this to ever happen, but just to please typescript...
-⋮----
-// We're over the max topics per request limit. Break into batches.
-⋮----
-// throw new Error(
-//   'CB INTX is not fully implemented yet - awaiting test environment... if you need this, please get in touch.',
-// );
-⋮----
-// Don't expect this to ever happen, but just to please typescript...
-⋮----
-// throw new Error(
-//   'CB Prime is not fully implemented yet - awaiting test environment... if you need this, please get in touch.',
-// );
-⋮----
-// throw new Error(`Not implemented for "${wsKey}" yet`);
-⋮----
-/**
-   * Events are signed per-request, so this function isn't needed for Coinbase.
-   */
-protected async getWsAuthRequestEvent(wsKey: WsKey): Promise<object>
-
-================
-File: .gitignore
-================
-examples/futures-private-test.ts
-examples/spot-private-test.ts
-node_modules
-
-rest-spot-private-ts-test.ts
-
-localtest.sh
-testfile.ts
-dist
-cbtests.sh
-doc
-
-coverage
-ts-adv-trade-test-private.ts
-examples/ts-app-priv.ts
-examples/ts-commerce.ts
-ts-exchange-priv.ts
-testfile-cbexch.ts
-restClientRegex.ts
-privaterepotracker.txt
-examples/_TiagoTests
-testfile.ts
-cbapidocs.txt
-repomix.sh
+// global headers for every request
 
 ================
 File: src/lib/BaseWSClient.ts
@@ -9386,278 +9619,1649 @@ protected async assertIsConnected(wsKey: TWSKey): Promise<unknown>
 // Start connection, it should automatically store/return a promise.
 
 ================
-File: src/lib/BaseRestClient.ts
+File: .gitignore
 ================
-import axios, { AxiosRequestConfig, AxiosResponse, Method } from 'axios';
-// NOTE: https.Agent is Node.js-only and not available in browser environments
-// Browser builds (via webpack) exclude this module - see webpack.config.js fallback settings
-import https from 'https';
-import { nanoid } from 'nanoid';
+examples/futures-private-test.ts
+examples/spot-private-test.ts
+node_modules
+
+rest-spot-private-ts-test.ts
+
+localtest.sh
+testfile.ts
+dist
+cbtests.sh
+doc
+
+coverage
+ts-adv-trade-test-private.ts
+examples/ts-app-priv.ts
+examples/ts-commerce.ts
+ts-exchange-priv.ts
+testfile-cbexch.ts
+restClientRegex.ts
+privaterepotracker.txt
+examples/_TiagoTests
+examples/ignored/
+testfile.ts
+cbapidocs.txt
+repomix.sh
+
+================
+File: src/types/websockets/client.ts
+================
+import type { ClientRequestArgs } from 'http';
+import WebSocket from 'isomorphic-ws';
 ⋮----
-import {
-  CloseAdvTradePositionRequest,
-  SubmitAdvTradeOrderRequest,
-} from '../types/request/advanced-trade-client.js';
-import { SubmitCBExchOrderRequest } from '../types/request/coinbase-exchange.js';
-import { SubmitINTXOrderRequest } from '../types/request/coinbase-international.js';
-import { SubmitPrimeOrderRequest } from '../types/request/coinbase-prime.js';
-import { CustomOrderIdProperty } from '../types/shared.types.js';
-import { signJWT } from './jwtNode.js';
-import { neverGuard } from './misc-util.js';
-import {
-  APIIDPrefix,
-  getRestBaseUrl,
-  logInvalidOrderId,
-  REST_CLIENT_TYPE_ENUM,
-  RestClientOptions,
-  RestClientType,
-  serializeParams,
-} from './requestUtils.js';
-import { signMessage } from './webCryptoAPI.js';
+/** General configuration for the WebsocketClient */
+export interface WSClientConfigurableOptions {
+  /**
+   * Your API key name.
+   *
+   * - For the Advanced Trade or App APIs, this is your API Key Name.
+   */
+  apiKey?: string;
+
+  /**
+   * Your API key secret.
+   *
+   * - For the Advanced Trade or App APIs, this is your API private key (including the -----BEGIN EC PRIVATE KEY-----\n etc).
+   */
+  apiSecret?: string;
+
+  /**
+   * Your API passphrase (NOT your account password). Only used for the API groups that use an API passphrase:
+   * - Coinbase Exchange API
+   * - Coinbase International API
+   * - Coinbase Prime API
+   */
+  apiPassphrase?: string;
+
+  /**
+   * For JWT auth (adv trade & app API), seconds until jwt expires. Defaults to 120 seconds.
+   */
+  jwtExpiresSeconds?: number;
+
+  /** How often to check if the connection is alive */
+  pingInterval?: number;
+
+  /** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+  pongTimeout?: number;
+
+  /** Delay in milliseconds before respawning the connection */
+  reconnectTimeout?: number;
+
+  wsUrl?: string;
+
+  wsOptions?: {
+    protocols?: string[];
+    agent?: any;
+  } & (
+    | Omit<Partial<WebSocket.ClientOptions>, 'agent'>
+    | Omit<Partial<ClientRequestArgs>, 'agent'>
+  );
+
+  /**
+   * Connect to the sandbox for supported products
+   *
+   * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
+   * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
+   *
+   * - Coinbase Advanced Trade: No WebSocket sandbox (REST static sandbox only via RestClientOptions.useSandbox).
+   * - Coinbase App: No sandbox available.
+   * - Coinbase Prime: No sandbox available.
+   */
+  useSandbox?: boolean;
+
+  /**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+  customSignMessageFn?: (message: string, secret: string) => Promise<string>;
+
+  /**
+   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
+   */
+  reauthWSAPIOnReconnect?: boolean;
+}
 ⋮----
-interface SignedRequest<T extends object | undefined = {}> {
-  originalParams: T;
-  paramsWithSign?: T & { sign: string };
-  serializedParams: string;
-  sign: string;
-  queryParamsWithSign: string;
-  timestamp: number;
+/**
+   * Your API key name.
+   *
+   * - For the Advanced Trade or App APIs, this is your API Key Name.
+   */
+⋮----
+/**
+   * Your API key secret.
+   *
+   * - For the Advanced Trade or App APIs, this is your API private key (including the -----BEGIN EC PRIVATE KEY-----\n etc).
+   */
+⋮----
+/**
+   * Your API passphrase (NOT your account password). Only used for the API groups that use an API passphrase:
+   * - Coinbase Exchange API
+   * - Coinbase International API
+   * - Coinbase Prime API
+   */
+⋮----
+/**
+   * For JWT auth (adv trade & app API), seconds until jwt expires. Defaults to 120 seconds.
+   */
+⋮----
+/** How often to check if the connection is alive */
+⋮----
+/** How long to wait for a pong (heartbeat reply) before assuming the connection is dead */
+⋮----
+/** Delay in milliseconds before respawning the connection */
+⋮----
+/**
+   * Connect to the sandbox for supported products
+   *
+   * - Coinbase Exchange: https://docs.cdp.coinbase.com/exchange/docs/sandbox
+   * - Coinbase International: https://docs.cdp.coinbase.com/intx/docs/sandbox
+   *
+   * - Coinbase Advanced Trade: No WebSocket sandbox (REST static sandbox only via RestClientOptions.useSandbox).
+   * - Coinbase App: No sandbox available.
+   * - Coinbase Prime: No sandbox available.
+   */
+⋮----
+/**
+   * Allows you to provide a custom "signMessage" function, e.g. to use node's much faster createHmac method
+   *
+   * Look in the examples folder for a demonstration on using node's createHmac instead.
+   */
+⋮----
+/**
+   * If you authenticated the WS API before, automatically try to re-authenticate the WS API if you're disconnected/reconnected for any reason.
+   */
+⋮----
+/**
+ * WS configuration that's always defined, regardless of user configuration
+ * (usually comes from defaults if there's no user-provided values)
+ */
+export interface WebsocketClientOptions extends WSClientConfigurableOptions {
+  pingInterval: number;
+  pongTimeout: number;
+  reconnectTimeout: number;
+  useSandbox: boolean;
   recvWindow: number;
-  headers: object;
+  /**
+   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
+   */
+  requireConnectionReadyConfirmation: boolean;
+  authPrivateConnectionsOnConnect: boolean;
+  authPrivateRequests: boolean;
+  reauthWSAPIOnReconnect: boolean;
 }
 ⋮----
-interface UnsignedRequest<T extends object | undefined = {}> {
-  originalParams: T;
-  paramsWithSign: T;
+/**
+   * If true, require a "receipt" that the connection is ready for use (e.g. a specific event type)
+   */
+⋮----
+export type WsMarket = 'advancedTrade' | 'exchange' | 'international' | 'prime';
+
+================
+File: docs/COINBASE_SDK_QUICKSTART_GUIDE.md
+================
+<!-- siebly:metadata
+siebly:
+  version: 1
+  hero:
+    headline: Coinbase API JavaScript Tutorial for Node.js
+    badges:
+      - Advanced Trade
+      - Spot
+      - US Futures
+      - International Perpetuals
+      - Public WebSockets
+      - Private WebSockets
+      - Sandboxes
+    summary: Build Coinbase integrations with Advanced Trade REST API calls, public and private WebSocket streams, safe order previews, reconnect recovery, sandbox guidance, and proxy support.
+    codeFilename: first-coinbase-api-call.js
+    codeStatus: public REST API
+    startSectionId: start-building-first-calls
+  software:
+    description: Node.js and JavaScript SDK for Coinbase Advanced Trade, Coinbase App, Exchange, International Exchange, Prime, and legacy Commerce REST APIs, plus public and private WebSocket streams.
+    topics:
+      - Coinbase Advanced Trade API
+      - Coinbase App API
+      - Coinbase Exchange API
+      - Coinbase International Exchange API
+      - Coinbase Prime API
+      - Coinbase Commerce API
+      - Public and private WebSockets
+      - Order previews
+      - Exchange and International sandboxes
+      - HTTP and SOCKS proxies
+      - Reconnect recovery
+  machineCatalog:
+    label: Coinbase API JavaScript Tutorial
+    topics:
+      - Advanced Trade products
+      - REST API response shapes
+      - public WebSocket streams
+      - private WebSocket streams
+      - safe order previews
+      - client order IDs
+      - API clients and environments
+      - HTTP and SOCKS proxies
+      - reconnect recovery
+  sdkPagePromo:
+    descriptionBeforePackage: 'A practical JavaScript guide to using '
+    descriptionAfterPackage: ' across Coinbase Advanced Trade REST API calls, public and private WebSocket streams, safe order previews, sandboxes, proxies, and reconnect recovery.'
+    highlights:
+      - Advanced Trade public and private REST API calls
+      - Public and private Advanced Trade WebSocket streams
+      - Safe Spot order-preview workflow
+      - REST API and WebSocket proxy examples
+    exampleHref: /examples/Coinbase
+    exampleLabel: Coinbase SDK examples
+    architectureClientSummary: CBAdvancedTradeClient, WebsocketClient, and specialized Coinbase REST API clients
+    architectureApiTitle: Coinbase APIs
+    architectureApiSummary: Advanced Trade, Coinbase App, Exchange, International Exchange, Prime, Commerce, and WebSocket streams
+  surfaceMap:
+    heading: Choose the Coinbase client for the job
+    summary: Start with Advanced Trade for retail trading, then use a specialized client only when the account belongs to another Coinbase API product.
+    appLabel: Bot, dashboard, worker, tool
+    appSummary: Any Node.js or JavaScript-compatible service that needs Coinbase market data, account state, order management, payments, or reconciliation.
+    apiLabel: Coinbase APIs
+    apiItems:
+      - Advanced Trade REST API calls
+      - Advanced Trade public and private streams
+      - Coinbase App account and transfer calls
+      - Exchange and International institutional APIs
+      - Prime trading and custody APIs
+      - Legacy Commerce APIs
+    packageNodes:
+      - label: CBAdvancedTradeClient
+        summary: Advanced Trade products, accounts, orders, portfolios, derivatives, conversions, fees, and payment methods
+      - label: WebsocketClient
+        summary: Advanced Trade, Exchange, International, and Prime WebSocket subscriptions
+      - label: CBAppClient
+        summary: Coinbase App accounts, addresses, transactions, deposits, withdrawals, and public prices
+      - label: CBExchangeClient
+        summary: Institutional Exchange market data, accounts, orders, profiles, reports, loans, and transfers
+      - label: CBInternationalClient
+        summary: International instruments, portfolios, orders, positions, loans, and transfers
+      - label: CBPrimeClient
+        summary: Prime portfolios, balances, orders, activities, allocations, wallets, and transactions
+      - label: CBCommerceClient
+        summary: Legacy Commerce charges, checkouts, and events
+  routing:
+    id: coinbase-request-routing
+    eyebrow: Request routing
+    heading: Product, portfolio, connection, and API family are separate choices
+    summary: Keep these values explicit so each request reaches the intended Coinbase product and account.
+    rows:
+      - eyebrow: Product ID
+        code: "product_id: 'BTC-USD'"
+        summary: Select an Advanced Trade Spot, futures, or perpetual product.
+      - eyebrow: Product metadata
+        code: "base_increment and price_increment"
+        summary: Apply current size and price rules before an order request.
+      - eyebrow: Portfolio
+        code: "portfolio_uuid"
+        summary: Scope balances, positions, and permissions to the intended portfolio.
+      - eyebrow: Client order ID
+        code: "client_order_id"
+        summary: Give an application-owned order a stable identifier.
+      - eyebrow: WebSocket connection
+        code: "WS_KEY_MAP.advTradeMarketData"
+        summary: Route a subscription to the correct public or private connection.
+      - eyebrow: API family
+        code: "CBAdvancedTradeClient"
+        summary: Select the REST API and authentication model used by the account.
+  coverage:
+    heading: What to get right in a Coinbase integration
+    summary: Start with Advanced Trade public data, then add credentials, private state, streams, safe validation, network configuration, and recovery.
+    cards:
+      - heading: Advanced Trade REST API calls
+        summary: Read endpoint-specific response objects and let the SDK generate JWTs for private requests.
+      - heading: Public and private WebSocket streams
+        summary: Select the correct connection with WS_KEY_MAP and distinguish acknowledgements from updates.
+      - heading: Safe order previews
+        summary: Validate a current order configuration without submitting it to the matching engine.
+      - heading: API families, sandboxes, and proxies
+        summary: Match the client to the Coinbase account, then configure the intended environment and network route.
+  snippets:
+    heading: First REST API calls, streams, order preview, recovery, and proxies
+    summary: Run one focused JavaScript example at a time, then add production controls around the same clients.
+    labels:
+      public-rest: Public REST API
+      private-rest: Private REST API
+      public-websocket: Public WebSocket
+      private-websocket: Private WebSocket
+      spot-order-preview: Spot order preview
+      reconnect-recovery: Reconnect recovery
+      http-proxy: HTTP or HTTPS proxy
+      socks-proxy: SOCKS5 proxy
+  workflows:
+    heading: REST API, WebSocket, and order-preview workflows
+    summary: REST API results, subscription acknowledgements, stream updates, and order previews carry different information.
+    diagrams:
+      - heading: REST API request flow
+        summary: Choose the Advanced Trade method, let the SDK sign private requests, then read the endpoint-specific result.
+        steps:
+          - label: Choose product and method
+            owner: app
+          - label: Call the SDK client
+            owner: app
+          - label: Route and sign if private
+            owner: sdk
+          - label: Receive endpoint response
+            owner: exchange
+          - label: Use returned fields
+            owner: app
+      - heading: WebSocket subscription flow
+        summary: Choose a topic and wsKey, let the SDK connect and authenticate when needed, then process acknowledgements and updates separately.
+        steps:
+          - label: Choose topic and wsKey
+            owner: app
+          - label: Call subscribe
+            owner: app
+          - label: Connect and sign if private
+            owner: sdk
+          - label: Receive subscriptions response
+            owner: event
+          - label: Process update events
+            owner: app
+      - heading: Safe order-preview flow
+        summary: Read current product rules, preview the order, inspect validation results, and stop without submitting an order.
+        steps:
+          - label: Read product metadata
+            owner: app
+          - label: Build order configuration
+            owner: app
+          - label: Call previewOrder
+            owner: app
+          - label: Inspect errors and totals
+            owner: exchange
+          - label: Stop before submission
+            owner: app
+  production:
+    heading: Before a Coinbase integration trades unattended
+    summary: Credentials, product rules, response handling, WebSocket continuity, recovery, and network behavior must all be predictable.
+    items:
+      - Keep API keys server-side and grant only the permissions each process needs.
+      - Keep product ID, portfolio, API family, and wsKey explicit in code and logs.
+      - Set client_order_id on application-owned orders so retries and restarts can reconcile them.
+      - Read product increments, minimum sizes, status flags, and venue before validating an order.
+      - Check both HTTP errors and operation-level success fields on order-management responses.
+      - Treat an accepted write as pending until a private stream or REST API query confirms state.
+      - Subscribe to heartbeats and reload private state after stream gaps.
+      - Keep the system clock synchronized and respect current Coinbase rate limits.
+      - Monitor proxy reachability, latency, and egress IP when a proxy is enabled.
+  journeys:
+    eyebrow: Choose your path
+    heading: Jump to the Coinbase workflow you are building
+    actionLabel: Open section
+    cards:
+      - heading: Start with REST API calls
+        summary: Make public market calls, add credentials, then inspect accounts and order state.
+        href: "#start-building-first-calls"
+      - heading: Stream live data
+        summary: Subscribe to public ticker data and private Advanced Trade order updates.
+        href: "#websocket-streams"
+      - heading: Understand order management
+        summary: Preview an order safely, then learn how submission, lookup, cancellation, and confirmation fit together.
+        href: "#order-management"
+      - heading: Configure connectivity
+        summary: Match the client to the Coinbase environment, then add an HTTP or SOCKS proxy when required.
+        href: "#api-hosts"
+  article:
+    heading: Build around Coinbase products and account state
+    summary: "This tutorial covers the Coinbase API pieces developers usually need first: Advanced Trade REST API calls, public and private streams, safe order previews, API environments, proxies, and reconnect recovery."
+  related:
+    cards:
+      - heading: Coinbase SDK page
+        summary: Return to installation, examples, endpoint maps, and package links.
+        href: /sdk/coinbase/javascript
+      - heading: Coinbase examples
+        summary: Browse runnable REST API and WebSocket examples.
+        href: /examples/Coinbase
+      - heading: Endpoint map
+        summary: Find the SDK method for each supported Coinbase endpoint.
+        href: https://github.com/tiagosiebler/coinbase-api/blob/master/docs/endpointFunctionList.md
+      - heading: Source repository
+        summary: Browse SDK source, releases, issues, and endpoint coverage on GitHub.
+        href: https://github.com/tiagosiebler/coinbase-api
+-->
+
+# Coinbase API JavaScript Tutorial for Node.js
+
+<!-- siebly:website-omit:start -->
+
+> [!TIP]
+> Read this guide in tutorial format on the Siebly website: [Coinbase JavaScript REST API and WebSocket Tutorial](https://siebly.io/sdk/coinbase/javascript/tutorial)
+
+<!-- siebly:website-omit:end -->
+
+This tutorial uses [`coinbase-api`](https://www.npmjs.com/package/coinbase-api), Siebly's Node.js and JavaScript SDK for Coinbase. This guide will primarily walk you through using the Coinbase Advanced Trade APIs & WebSockets for public market data, authenticated account access, WebSocket streams, and safe order previews.
+
+The SDK handles REST API authentication, short-lived JWT creation, product-specific WebSocket routing, private subscription signing, reconnects, and resubscriptions. It also provides focused clients for Coinbase App, Exchange, International Exchange, Prime, and legacy Commerce APIs.
+
+**Key links**
+
+- Coinbase JavaScript SDK by Siebly: [`coinbase-api`](https://siebly.io/sdk/coinbase/javascript)
+- npm package: [`coinbase-api`](https://www.npmjs.com/package/coinbase-api)
+- GitHub repository: [`tiagosiebler/coinbase-api`](https://github.com/tiagosiebler/coinbase-api)
+- SDK examples: [Coinbase SDK examples](https://siebly.io/examples/Coinbase)
+- SDK endpoint map: [Coinbase JavaScript endpoint reference](./endpointFunctionList.md)
+- Official documentation: [Coinbase Developer Documentation](https://docs.cdp.coinbase.com/)
+- Advanced Trade REST API: [Advanced Trade API endpoints](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/rest-api)
+- Advanced Trade WebSockets: [WebSocket overview](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/websocket/websocket-overview)
+- API authentication: [Coinbase App API key authentication](https://docs.cdp.coinbase.com/coinbase-app/authentication-authorization/api-key-authentication)
+- Trading-system terms: [Siebly glossary](https://siebly.io/reference/glossary)
+- More JavaScript SDKs: [Siebly.io](https://siebly.io)
+
+## Why use `coinbase-api`?
+
+Private Advanced Trade REST API requests use short-lived JSON Web Tokens signed with a Coinbase Developer Platform API key. Private WebSocket subscriptions also need a fresh JWT, and each subscription must reach the correct Coinbase connection.
+
+`coinbase-api` handles those mechanics and provides a focused client for each API family, so you can focus on your integration without excessive plumbing efforts:
+
+| Client                  | Use it for                                                                             |
+| ----------------------- | -------------------------------------------------------------------------------------- |
+| `CBAdvancedTradeClient` | Advanced Trade products, accounts, orders, portfolios, derivatives, fees, and converts |
+| `WebsocketClient`       | Advanced Trade, Exchange, International, and Prime WebSocket streams                   |
+| `CBAppClient`           | Coinbase App accounts, addresses, transactions, deposits, withdrawals, and prices      |
+| `CBExchangeClient`      | Institutional Exchange market data, trading, profiles, reports, loans, and transfers   |
+| `CBInternationalClient` | International instruments, portfolios, orders, positions, loans, and transfers         |
+| `CBPrimeClient`         | Prime portfolios, balances, orders, activities, allocations, wallets, and transactions |
+| `CBCommerceClient`      | Legacy Commerce charges, checkouts, and events                                         |
+
+The Advanced Trade product group is the right starting point for most developers automating their own Coinbase trading account. The other REST API clients use different account products, credentials, permissions, and sometimes an API passphrase. These are typically catered more towards institutional users.
+
+## Install the SDK
+
+```bash
+npm install coinbase-api
+```
+
+The examples use standard ES module imports. The package also supports CommonJS projects.
+
+## Create Coinbase API keys
+
+Public Advanced Trade REST API calls and public WebSocket streams do not need credentials. Private calls and the private `user` stream need a Coinbase Developer Platform secret API key.
+
+Store the key name and private key in environment variables:
+
+```bash
+COINBASE_API_KEY_NAME
+COINBASE_API_PRIVATE_KEY
+```
+
+The key name is the API key identifier returned by Coinbase. For ECDSA keys it normally has the form `organizations/{organization_id}/apiKeys/{key_id}`. The private key is the secret signing key, not a Coinbase account password.
+
+`coinbase-api` accepts the current ECDSA PEM and base64 Ed25519 key formats and detects the signing algorithm automatically. Preserve the private key exactly, including PEM boundaries and line breaks when using an ECDSA key.
+
+When creating a key:
+
+- Grant `view` permission for private account reads and order previews.
+- Grant `trade` only to a process that will place or manage orders.
+- Grant `transfer` or `receive` only when the process genuinely needs those actions.
+- Restrict the key to the intended portfolio.
+- Add an IP allowlist when the process has stable outbound addresses.
+- Keep the private key in a server-side secret store and never send it to browser code.
+
+Nothing executable in this tutorial needs transfer or withdrawal access. The order example uses `previewOrder()` and does not submit an order.
+
+Advanced Trade and Coinbase App keys do not use an API passphrase. Coinbase Exchange, International Exchange, and Prime credentials use a separate API key, secret, and passphrase.
+
+## Coinbase products and request vocabulary
+
+Several values determine which market, account, and connection a request uses:
+
+| Field or value         | Example                                    | Meaning                                                                                   |
+| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------- |
+| Product ID             | `BTC-USD`                                  | Hyphen-separated trading product with BTC as the base and USD as the quote currency       |
+| `base_increment`       | Product metadata                           | Smallest supported change to a base-currency size                                         |
+| `quote_increment`      | Product metadata                           | Smallest supported change to a quote-currency size                                        |
+| `price_increment`      | Product metadata                           | Smallest supported change to an order price                                               |
+| `base_min_size`        | Product metadata                           | Minimum supported base-currency size                                                      |
+| `quote_min_size`       | Product metadata                           | Minimum supported quote-currency size                                                     |
+| Product status flags   | `status`, `trading_disabled`, `limit_only` | Current restrictions that affect valid order requests                                     |
+| Product type and venue | `product_type`, `product_venue`            | Distinguish Spot, US futures, and International perpetual products                        |
+| Portfolio ID           | `portfolio_uuid`                           | Portfolio that owns balances, permissions, orders, or derivative positions                |
+| Client order ID        | `client_order_id`                          | Application-owned [custom order ID](https://siebly.io/reference/glossary#custom-order-id) |
+| Order configuration    | `market_market_ioc`, `limit_limit_gtc`     | Order type, size, time in force, price, and post-only behavior                            |
+| WebSocket key          | `WS_KEY_MAP.advTradeMarketData`            | [WebSocket key](https://siebly.io/reference/glossary#ws-key) selecting the connection     |
+
+Advanced Trade REST API methods return the endpoint body directly. There is no shared success envelope. Products are objects, accounts and orders are arrays nested inside response objects, and candles are objects inside a `candles` array.
+
+<!-- siebly:section id="start-building-first-calls" -->
+
+## Start building: first calls and streams
+
+Run each example on its own. Start with public market data, then add credentials, private state, streams, and an order preview.
+
+### 1. Make public REST API calls
+
+Public calls need no API key.
+
+<!-- siebly:snippet id="public-rest" -->
+
+```javascript
+import { CBAdvancedTradeClient } from 'coinbase-api';
+
+const client = new CBAdvancedTradeClient();
+
+async function main() {
+  try {
+    const serverTime = await client.getServerTime();
+    console.log('Server time:', serverTime.iso);
+  } catch (error) {
+    console.error('Server time request failed:', error);
+  }
+
+  try {
+    const product = await client.getPublicProduct({
+      product_id: 'BTC-USD',
+    });
+    console.log('BTC-USD price:', product.price);
+    console.log('Base increment:', product.base_increment);
+    console.log('Price increment:', product.price_increment);
+  } catch (error) {
+    console.error('Product request failed:', error);
+  }
+
+  try {
+    const orderBook = await client.getPublicProductBook({
+      product_id: 'BTC-USD',
+      limit: 5,
+    });
+    console.log('Best bid:', orderBook.pricebook.bids[0]);
+    console.log('Best ask:', orderBook.pricebook.asks[0]);
+  } catch (error) {
+    console.error('Order book request failed:', error);
+  }
+
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - 60 * 60;
+
+  try {
+    const candles = await client.getPublicProductCandles({
+      product_id: 'BTC-USD',
+      start: String(start),
+      end: String(end),
+      granularity: 'FIVE_MINUTE',
+      limit: 12,
+    });
+    console.log('Latest candle:', candles.candles[0]);
+  } catch (error) {
+    console.error('Candles request failed:', error);
+  }
+
+  try {
+    const marketTrades = await client.getPublicMarketTrades({
+      product_id: 'BTC-USD',
+      limit: 10,
+    });
+    console.log('Latest trade:', marketTrades.trades[0]);
+    console.log('Best bid:', marketTrades.best_bid);
+    console.log('Best ask:', marketTrades.best_ask);
+  } catch (error) {
+    console.error('Market trades request failed:', error);
+  }
 }
-⋮----
-type SignMethod = 'coinbase';
-⋮----
-/**
- * Some requests require some params to be in the query string, some in the body, some even in the headers.
- * This type anticipates either are possible in any combination.
- *
- * The request builder will automatically handle where parameters should go.
- */
-type ParamsInRequest = {
-  query?: object;
-  body?: object;
-  headers?: object;
-};
-⋮----
-// request: {
-//   url: response.config.url,
-//   method: response.config.method,
-//   data: response.config.data,
-//   headers: response.config.headers,
-// },
-⋮----
-/**
- * Impure, mutates params to remove any values that have a key but are undefined.
- */
-function deleteUndefinedValues(params?: any): void
-⋮----
-export abstract class BaseRestClient
-⋮----
-/** Defines the client type (affecting how requests & signatures behave) */
-abstract getClientType(): RestClientType;
-⋮----
-/**
-   * Create an instance of the REST client. Pass API credentials in the object in the first parameter.
-   * @param {RestClientOptions} [restClientOptions={}] options to configure REST API connectivity
-   * @param {AxiosRequestConfig} [networkOptions={}] HTTP networking options for axios
-   */
-constructor(
-    restClientOptions: RestClientOptions = {},
-    networkOptions: AxiosRequestConfig = {},
-)
-⋮----
-/** Throw errors if any request params are empty */
-⋮----
-/** in ms == 5 minutes by default */
-⋮----
-/** inject custom rquest options based on axios specs - see axios docs for more guidance on AxiosRequestConfig: https://github.com/axios/axios#request-config */
-⋮----
-// If enabled, configure a https agent with keepAlive enabled
-// NOTE: This is Node.js-only functionality. In browser environments, this code is skipped
-// as the 'https' module is excluded via webpack fallback configuration.
-// Browser connection pooling is handled automatically by the browser itself.
-⋮----
-// Extract existing https agent parameters, if provided, to prevent the keepAlive flag from overwriting an existing https agent completely
-⋮----
-// For more advanced configuration, raise an issue on GitHub or use the "networkOptions"
-// parameter to define a custom httpsAgent with the desired properties
-⋮----
-// Newline escapes needed, if passed as env vars
-⋮----
-// Throw if one of these values is missing, and at least one of them is set
-⋮----
-// commerce only needs keys, not key and secret
-⋮----
-/**
-   * Timestamp used to sign the request. Override this method to implement your own timestamp/sync mechanism
-   */
-getSignTimestampMs(): number
-⋮----
-get(endpoint: string, params?: object)
-⋮----
-post(endpoint: string, params?: ParamsInRequest)
-⋮----
-getPrivate(endpoint: string, params?: object)
-⋮----
-postPrivate(endpoint: string, params?: ParamsInRequest)
-⋮----
-deletePrivate(endpoint: string, params?: ParamsInRequest)
-⋮----
-putPrivate(endpoint: string, params?: ParamsInRequest)
-⋮----
-patchPrivate(endpoint: string, params?: ParamsInRequest)
-⋮----
-/**
-   * @private Make a HTTP request to a specific endpoint. Private endpoint API calls are automatically signed.
-   */
-private async _call(
-    method: Method,
-    endpoint: string,
-    params?: ParamsInRequest,
-    isPublicApi?: boolean,
-): Promise<any>
-⋮----
-// Sanity check to make sure it's only ever prefixed by one forward slash
-⋮----
-// Build a request and handle signature process
-⋮----
-// Dispatch request
-⋮----
-// Throw if API returns an error (e.g. insufficient balance)
-⋮----
-public generateNewOrderId(): string
-⋮----
-/**
-   * Validate syntax meets requirements set by coinbase. Log warning if not.
-   */
-protected validateOrderId(
-    params:
-      | SubmitAdvTradeOrderRequest
-      | CloseAdvTradePositionRequest
-      | SubmitCBExchOrderRequest
-      | SubmitINTXOrderRequest
-      | SubmitPrimeOrderRequest,
-    orderIdProperty: CustomOrderIdProperty,
-): void
-⋮----
-// Not the cleanest but strict checks aren't quite necessary here either
-⋮----
-/**
-   * @private generic handler to parse request exceptions
-   */
-parseException(e: any, requestParams: any): unknown
-⋮----
-// Something happened in setting up the request that triggered an error
-⋮----
-// request made but no response received
-⋮----
-// The request was made and the server responded with a status code
-// that falls out of the range of 2xx
-⋮----
-// console.error('err: ', response?.data);
-⋮----
-// Prevent credentials from leaking into error messages
-⋮----
-/**
-   * @private sign request and set recv window
-   */
-private async signRequest<T extends ParamsInRequest | undefined = {}>(
-    data: T,
-    url: string,
-    endpoint: string,
-    method: Method,
-    signMethod: SignMethod,
-): Promise<SignedRequest<T>>
-⋮----
-// if there is body, use body - otherwise empty string
-⋮----
-// https://docs.cdp.coinbase.com/product-apis/docs/welcome
-⋮----
-// Both adv trade & app API use the same JWT auth mechanism
-// Advanced Trade: https://docs.cdp.coinbase.com/advanced-trade/docs/rest-api-auth
-// App: https://docs.cdp.coinbase.com/coinbase-app/docs/api-key-authentication
-⋮----
-// TODO: is there demand for oauth support?
-// Docs: https://docs.cdp.coinbase.com/coinbase-app/docs/coinbase-app-integration
-// See: https://github.com/tiagosiebler/coinbase-api/issues/24
-⋮----
-// Docs: https://docs.cdp.coinbase.com/exchange/docs/rest-auth
-⋮----
-const timestampInSeconds = timestampInMs / 1000; // decimals are OK
-⋮----
-// console.log('sign res: ', { signInput, ...headers });
-⋮----
-// For CB Exchange, is there demand for FIX
-// Docs, FIX: https://docs.cdp.coinbase.com/exchange/docs/fix-connectivity
-⋮----
-// Docs: https://docs.cdp.coinbase.com/intx/docs/rest-auth
-⋮----
-const timestampInSeconds = timestampInMs / 1000; // decimals are OK
-⋮----
-// For CB International, no query params are used in the signature
-⋮----
-// console.log('sign res: ', { signInput, ...headers });
-⋮----
-// For CB International, is there demand for FIX
-// Docs, FIX: https://docs.cdp.coinbase.com/intx/docs/fix-overview
-⋮----
-// Docs: https://docs.cdp.coinbase.com/prime/docs/rest-authentication
-⋮----
-const timestampInSeconds = Math.floor(timestampInMs / 1000); // decimal not allowed
-⋮----
-// For CB Prime, is there demand for FIX
-// Docs, FIX: https://docs.cdp.coinbase.com/prime/docs/fix-connectivity
-⋮----
-// https://docs.cdp.coinbase.com/commerce-onchain/docs/getting-started
-// No auth?
-⋮----
-private async prepareSignParams<TParams extends object | undefined>(
-    method: Method,
-    url: string,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: true,
-  ): Promise<UnsignedRequest<TParams>>;
-⋮----
-private async prepareSignParams<TParams extends object | undefined>(
-    method: Method,
-    url: string,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: false | undefined,
-  ): Promise<SignedRequest<TParams>>;
-⋮----
-private async prepareSignParams<TParams extends object | undefined>(
-    method: Method,
-    url: string,
-    endpoint: string,
-    signMethod: SignMethod,
-    params?: TParams,
-    isPublicApi?: boolean,
-)
-⋮----
-/** Returns an axios request object. Handles signing process automatically if this is a private API call */
-private async buildRequest(
-    method: Method,
-    endpoint: string,
-    url: string,
-    params?: any | undefined,
-    isPublicApi?: boolean,
-): Promise<AxiosRequestConfig>
-⋮----
-// request parameter headers for this request
-⋮----
-// auth headers for this request
-⋮----
-// global headers for every request
+
+main();
+```
+
+The methods return different object shapes:
+
+| Method                      | Successful result                                                                        |
+| --------------------------- | ---------------------------------------------------------------------------------------- |
+| `getServerTime()`           | Object containing `iso`, `epochSeconds`, and `epochMillis`                               |
+| `getPublicProduct()`        | One product object                                                                       |
+| `getPublicProductBook()`    | Object containing `pricebook`, whose `bids` and `asks` are arrays of price-level objects |
+| `getPublicProductCandles()` | Object containing a `candles` array                                                      |
+| `getPublicMarketTrades()`   | Object containing `trades`, `best_bid`, and `best_ask`                                   |
+
+Each candle has named `start`, `low`, `high`, `open`, `close`, and `volume` fields. Prices, quantities, increments, and timestamps are commonly strings. Keep exchange values as strings until a calculation requires a deliberate conversion.
+
+### 2. Make private REST API calls
+
+The private client uses the same Advanced Trade class with a key name and private key. The SDK creates and signs a new JWT for each private request.
+
+<!-- siebly:snippet id="private-rest" -->
+
+```javascript
+import { CBAdvancedTradeClient } from 'coinbase-api';
+
+async function main() {
+  if (
+    !process.env.COINBASE_API_KEY_NAME ||
+    !process.env.COINBASE_API_PRIVATE_KEY
+  ) {
+    console.error('Set COINBASE_API_KEY_NAME and COINBASE_API_PRIVATE_KEY.');
+    return;
+  }
+
+  const client = new CBAdvancedTradeClient({
+    apiKey: process.env.COINBASE_API_KEY_NAME,
+    apiSecret: process.env.COINBASE_API_PRIVATE_KEY,
+  });
+
+  try {
+    const permissions = await client.getApiKeyPermissions();
+    console.log('Can view:', permissions.can_view);
+    console.log('Can trade:', permissions.can_trade);
+    console.log('Can transfer:', permissions.can_transfer);
+    console.log('Portfolio:', permissions.portfolio_uuid);
+  } catch (error) {
+    console.error('Permission request failed:', error);
+  }
+
+  try {
+    const accounts = await client.getAccounts({
+      limit: 10,
+    });
+    console.log('Accounts:', accounts.accounts);
+    console.log('More accounts available:', accounts.has_next);
+  } catch (error) {
+    console.error('Account request failed:', error);
+  }
+
+  try {
+    const openOrders = await client.getOrders({
+      order_status: ['OPEN'],
+      limit: 20,
+    });
+    console.log('Open orders:', openOrders.orders);
+    console.log('More orders available:', openOrders.has_next);
+  } catch (error) {
+    console.error('Open-order request failed:', error);
+  }
+
+  try {
+    const fills = await client.getFills({
+      product_ids: ['BTC-USD'],
+      limit: 20,
+    });
+    console.log('Recent BTC-USD fills:', fills.fills);
+    console.log('Next cursor:', fills.cursor);
+  } catch (error) {
+    console.error('Fill request failed:', error);
+  }
+}
+
+main();
+```
+
+`getAccounts()` and `getOrders()` expose pagination fields alongside their arrays. `getFills()` returns its `fills` array and an optional cursor. Follow the returned cursor when the application needs more than one page.
+
+HTTP failures are rejected as parsed errors containing the status, response body, headers, and request context. Credentials are omitted from those parsed error objects. Order-management methods can also return a successful HTTP response whose operation-level `success` field is `false`, so both layers must be checked.
+
+### 3. Subscribe to public Advanced Trade WebSocket streams
+
+Use the Advanced Trade market-data connection for public channels. Subscribe to `heartbeats` alongside the ticker so the connection remains active when another channel has no updates.
+
+<!-- siebly:snippet id="public-websocket" -->
+
+```javascript
+import { WebsocketClient, WS_KEY_MAP } from 'coinbase-api';
+
+function main() {
+  const ws = new WebsocketClient();
+
+  ws.on('open', ({ wsKey }) => {
+    console.log('WebSocket opened:', wsKey);
+  });
+
+  ws.on('response', (response) => {
+    console.log(
+      'WebSocket response:',
+      response.wsKey,
+      response.channel,
+      response.events,
+    );
+  });
+
+  ws.on('update', (update) => {
+    console.log(
+      'WebSocket update:',
+      update.wsKey,
+      update.channel,
+      update.events,
+    );
+  });
+
+  ws.on('reconnect', ({ wsKey }) => {
+    console.log('Reconnecting:', wsKey);
+  });
+
+  ws.on('reconnected', ({ wsKey }) => {
+    console.log('Reconnected:', wsKey);
+  });
+
+  ws.on('close', ({ wsKey }) => {
+    console.log('WebSocket closed:', wsKey);
+  });
+
+  ws.on('exception', (error) => {
+    console.error('WebSocket exception:', error);
+  });
+
+  ws.subscribe(
+    {
+      topic: 'ticker',
+      payload: {
+        product_ids: ['BTC-USD'],
+      },
+    },
+    WS_KEY_MAP.advTradeMarketData,
+  );
+
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
+
+  process.once('SIGINT', () => {
+    ws.closeAll();
+  });
+}
+
+main();
+```
+
+A message whose `channel` is `subscriptions` is the [subscription acknowledgement](https://siebly.io/reference/glossary#subscription-acknowledgement). Market snapshots and later changes arrive through `update`, where each event has a channel-specific shape and a `type` such as `snapshot` or `update`.
+
+The SDK adds `wsKey` to emitted events so one handler can identify the source connection. After an unexpected disconnect, it reconnects and restores tracked subscriptions.
+
+### 4. Subscribe to the private Advanced Trade user stream
+
+The private user-data connection provides order and position updates for the authenticated account. The SDK signs each subscription with a fresh JWT.
+
+<!-- siebly:snippet id="private-websocket" -->
+
+```javascript
+import { WebsocketClient, WS_KEY_MAP } from 'coinbase-api';
+
+function main() {
+  if (
+    !process.env.COINBASE_API_KEY_NAME ||
+    !process.env.COINBASE_API_PRIVATE_KEY
+  ) {
+    console.error('Set COINBASE_API_KEY_NAME and COINBASE_API_PRIVATE_KEY.');
+    return;
+  }
+
+  const ws = new WebsocketClient({
+    apiKey: process.env.COINBASE_API_KEY_NAME,
+    apiSecret: process.env.COINBASE_API_PRIVATE_KEY,
+  });
+
+  ws.on('open', ({ wsKey }) => {
+    console.log('Private WebSocket opened:', wsKey);
+  });
+
+  ws.on('response', (response) => {
+    console.log(
+      'Private WebSocket response:',
+      response.wsKey,
+      response.channel,
+      response.events,
+    );
+  });
+
+  ws.on('update', (update) => {
+    console.log('Private update:', update.wsKey, update.channel, update.events);
+  });
+
+  ws.on('reconnect', ({ wsKey }) => {
+    console.log('Private WebSocket reconnecting:', wsKey);
+  });
+
+  ws.on('reconnected', ({ wsKey }) => {
+    console.log('Private WebSocket reconnected:', wsKey);
+  });
+
+  ws.on('close', ({ wsKey }) => {
+    console.log('Private WebSocket closed:', wsKey);
+  });
+
+  ws.on('exception', (error) => {
+    console.error('Private WebSocket exception:', error);
+  });
+
+  ws.subscribe(
+    {
+      topic: 'user',
+      payload: {
+        product_ids: ['BTC-USD'],
+      },
+    },
+    WS_KEY_MAP.advTradeUserData,
+  );
+
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeUserData);
+
+  process.once('SIGINT', () => {
+    ws.closeAll();
+  });
+}
+
+main();
+```
+
+The first `user` messages contain the account's current open orders, followed by later order changes. Coinbase can split a large initial snapshot across multiple messages. Preserve the event type and sequence information when building local [account state](https://siebly.io/reference/glossary#accountstate).
+
+An eligible derivatives account can also subscribe to `futures_balance_summary` through `WS_KEY_MAP.advTradeUserData`. Keep that subscription separate from `user` because Coinbase requires one channel per subscription request.
+
+Private order updates provide [private stream confirmation](https://siebly.io/reference/glossary#private-stream-confirmation) after a write. A subscription acknowledgement only confirms the stream subscription, not an order state.
+
+### 5. Preview a Spot order with the REST API
+
+`previewOrder()` validates an order configuration and returns estimated totals, commission, market prices, warnings, and validation errors. It does not submit an order to the matching engine.
+
+This example reads the current `BTC-USD` minimum quote size and uses it for a market-buy preview.
+
+<!-- siebly:snippet id="spot-order-preview" -->
+
+```javascript
+import { CBAdvancedTradeClient } from 'coinbase-api';
+
+async function main() {
+  if (
+    !process.env.COINBASE_API_KEY_NAME ||
+    !process.env.COINBASE_API_PRIVATE_KEY
+  ) {
+    console.error('Set COINBASE_API_KEY_NAME and COINBASE_API_PRIVATE_KEY.');
+    return;
+  }
+
+  const client = new CBAdvancedTradeClient({
+    apiKey: process.env.COINBASE_API_KEY_NAME,
+    apiSecret: process.env.COINBASE_API_PRIVATE_KEY,
+  });
+
+  let product;
+
+  try {
+    product = await client.getPublicProduct({
+      product_id: 'BTC-USD',
+    });
+    console.log('Minimum quote size:', product.quote_min_size);
+  } catch (error) {
+    console.error('Product request failed:', error);
+    return;
+  }
+
+  if (
+    !product.quote_min_size ||
+    !Number.isFinite(Number(product.quote_min_size)) ||
+    Number(product.quote_min_size) <= 0
+  ) {
+    console.error('BTC-USD returned an invalid quote_min_size.');
+    return;
+  }
+
+  try {
+    const preview = await client.previewOrder({
+      product_id: 'BTC-USD',
+      side: 'BUY',
+      order_configuration: {
+        market_market_ioc: {
+          quote_size: product.quote_min_size,
+        },
+      },
+    });
+
+    console.log('Validation errors:', preview.errs);
+    console.log('Warnings:', preview.warning);
+    console.log('Order total:', preview.order_total);
+    console.log('Commission total:', preview.commission_total);
+    console.log('Best bid:', preview.best_bid);
+    console.log('Best ask:', preview.best_ask);
+    console.log('Preview ID:', preview.preview_id);
+  } catch (error) {
+    console.error('Order preview failed:', error);
+  }
+}
+
+main();
+```
+
+The preview endpoint needs `view` permission. Check `errs` before using any estimate. Warnings may describe conditions that do not make the request invalid, while an error means the configuration cannot currently be accepted.
+
+`preview_id` identifies this preview result. Passing it to a later order request does not remove the need to validate current product rules and check the order response. This tutorial stops after the preview and never calls `submitOrder()`.
+
+<!-- siebly:section id="rest-api" -->
+
+## Work with the Advanced Trade REST API
+
+### Understand response shapes
+
+Advanced Trade REST API methods return the endpoint body. The top-level shape depends on the method:
+
+| Operation       | Main response fields                                                   |
+| --------------- | ---------------------------------------------------------------------- |
+| List accounts   | `accounts`, `has_next`, `cursor`, `size`                               |
+| List orders     | `orders`, `has_next`, optional `cursor` and `sequence`                 |
+| List fills      | `fills`, optional `cursor`                                             |
+| Product book    | `pricebook`, with `bids`, `asks`, and `time`                           |
+| Product candles | `candles`                                                              |
+| Market trades   | `trades`, `best_bid`, `best_ask`                                       |
+| Submit order    | `success`, `success_response`, `error_response`, `order_configuration` |
+| Cancel orders   | `results`, with one result for each requested order ID                 |
+| Preview order   | `errs`, `warning`, totals, sizes, market prices, and `preview_id`      |
+
+Do not assume that a successful HTTP status means an order-management operation succeeded. For example, `submitOrder()` can return `success: false` with details under `error_response`.
+
+### Read account and order state
+
+The private methods used most often for account state are:
+
+| Method                    | Purpose                                                         |
+| ------------------------- | --------------------------------------------------------------- |
+| `getApiKeyPermissions()`  | Read the key's current permissions and portfolio scope          |
+| `getAccounts()`           | List currency accounts, available balances, and holds           |
+| `getAccount()`            | Read one currency account                                       |
+| `getOrders()`             | List orders using product, status, side, type, and time filters |
+| `getOrder()`              | Read one order by exchange order ID                             |
+| `getFills()`              | List fills by product, order, trade, time, or cursor            |
+| `getTransactionSummary()` | Read current volume and fee-tier information                    |
+
+Use cursors until the required history window is complete. Keep product IDs, order IDs, client order IDs, and cursor values with the data they identify.
+
+<!-- siebly:section id="order-management" -->
+
+## Understand Advanced Trade order management
+
+Advanced Trade order commands use `CBAdvancedTradeClient`. The `WebsocketClient` provides streams and does not send order commands.
+
+### Choose an order configuration
+
+The request's `order_configuration` contains one order type. Common configurations include:
+
+| Configuration                   | Use                                                                   |
+| ------------------------------- | --------------------------------------------------------------------- |
+| `market_market_ioc`             | Market order using a base or quote size                               |
+| `limit_limit_gtc`               | Limit order that remains active until filled or cancelled             |
+| `limit_limit_gtd`               | Limit order with an expiry time                                       |
+| `limit_limit_fok`               | Limit order that must fill completely and immediately or be cancelled |
+| `sor_limit_ioc`                 | Smart order-router limit order with immediate-or-cancel behavior      |
+| Stop and bracket configurations | Conditional exits and attached risk controls                          |
+
+A `limit_limit_gtc` configuration can set `post_only: true`. A post-only order is rejected or cancelled rather than immediately taking liquidity. It can still fill after resting on the book, so it is not a risk-free live test.
+
+Always apply current `base_increment`, `quote_increment`, `price_increment`, minimum sizes, maximum sizes, and product status flags. Derivative products add contract, margin, session, and eligibility rules.
+
+### Use client order IDs
+
+Call `client.generateNewOrderId()` when an application will submit an order. The SDK generates an identifier with its required `cbnode` prefix. If a supplied `client_order_id` does not have that prefix, the SDK adds it and logs a warning.
+
+Persist both the [custom order ID](https://siebly.io/reference/glossary#custom-order-id) and Coinbase order ID. The client order ID lets a process reconcile an uncertain request after a timeout or restart.
+
+### Follow the order lifecycle
+
+The main REST API methods are:
+
+| Method                 | Operation                                            |
+| ---------------------- | ---------------------------------------------------- |
+| `previewOrder()`       | Validate and estimate an order without submitting it |
+| `submitOrder()`        | Submit a new order                                   |
+| `getOrder()`           | Query one order                                      |
+| `getOrders()`          | List matching orders                                 |
+| `updateOrderPreview()` | Preview an order edit                                |
+| `updateOrder()`        | Edit an eligible order                               |
+| `cancelOrders()`       | Request cancellation for one or more order IDs       |
+
+For a submitted order:
+
+1. Check the HTTP request outcome.
+2. Check the returned `success` field.
+3. Read the Coinbase order ID from `success_response` only when `success` is `true`.
+4. Treat the result as [pending confirmation](https://siebly.io/reference/glossary#pending-confirmation).
+5. Confirm the final state through the private `user` stream or `getOrder()`.
+
+If a write times out without a clear result, query by the known Coinbase order ID or reconcile the client order ID before retrying. Blindly submitting the same intent again can create a second live order.
+
+### Know what WebSockets do
+
+`coinbase-api` does not expose a `WebsocketAPIClient` for Coinbase because its supported Coinbase WebSocket interfaces are subscription feeds. Use:
+
+- `WebsocketClient` for market and account updates.
+- `CBAdvancedTradeClient` for preview, submit, edit, query, and cancel commands.
+
+A subscription response acknowledges a channel. It is not an order acknowledgement and does not confirm account state.
+
+### Explore other Advanced Trade groups
+
+The Advanced Trade client covers more than Spot orders:
+
+| Group                     | Representative methods                                                                   |
+| ------------------------- | ---------------------------------------------------------------------------------------- |
+| Authenticated market data | `getProducts()`, `getProduct()`, `getBestBidAsk()`, `getProductBook()`                   |
+| Portfolios                | `getPortfolios()`, `getPortfolioBreakdown()`, `createPortfolio()`, `updatePortfolio()`   |
+| Fees                      | `getTransactionSummary()`                                                                |
+| Converts                  | `submitConvertQuote()`, `getConvertTrade()`, `commitConvertTrade()`                      |
+| Payment methods           | `getPaymentMethods()`, `getPaymentMethod()`                                              |
+| US futures                | `getFuturesBalanceSummary()`, `getFuturesPositions()`, `getFuturesSweeps()`              |
+| Futures margin            | `getIntradayMarginSetting()`, `getCurrentMarginWindow()`                                 |
+| International perpetuals  | `getPerpetualsPortfolioSummary()`, `getPerpetualsPositions()`, `getPortfoliosBalances()` |
+| International collateral  | `allocatePortfolio()`, `updateMultiAssetCollateral()`                                    |
+
+US futures and International perpetual products are available only to eligible accounts and jurisdictions. Read product metadata and account state rather than assuming that a product visible in public data is tradable by the authenticated portfolio.
+
+For the full method-to-endpoint map, use the [Coinbase SDK endpoint reference](./endpointFunctionList.md).
+
+<!-- siebly:section id="websocket-streams" -->
+
+## Build with Coinbase WebSocket streams
+
+### Choose the correct WebSocket key
+
+Each `wsKey` identifies one Coinbase WebSocket connection:
+
+| WebSocket key                         | Authentication | Use                                                         |
+| ------------------------------------- | -------------- | ----------------------------------------------------------- |
+| `WS_KEY_MAP.advTradeMarketData`       | Public         | Advanced Trade ticker, level 2, trades, candles, and status |
+| `WS_KEY_MAP.advTradeUserData`         | Required       | Advanced Trade user orders and futures balance summaries    |
+| `WS_KEY_MAP.exchangeMarketData`       | Public         | Coinbase Exchange market-data feed                          |
+| `WS_KEY_MAP.exchangeDirectMarketData` | Required       | Coinbase Exchange direct market-data feed                   |
+| `WS_KEY_MAP.internationalMarketData`  | Required       | Coinbase International market-data feed                     |
+| `WS_KEY_MAP.primeMarketData`          | Required       | Coinbase Prime market-data feed                             |
+
+Pass `WS_KEY_MAP` values explicitly. This keeps connection routing visible and prevents a topic from reaching the wrong API family.
+
+### Use the Advanced Trade channels
+
+| Channel                   | Authentication | Main use                                                                                                                    |
+| ------------------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `heartbeats`              | Public channel | Keep subscriptions open and detect missed heartbeat counts. On `advTradeUserData`, the SDK still signs the subscription JWT |
+| `ticker`                  | Public         | Price, volume, and best bid or ask changes                                                                                  |
+| `ticker_batch`            | Public         | Batched ticker changes                                                                                                      |
+| `market_trades`           | Public         | Recent trade updates                                                                                                        |
+| `level2`                  | Public         | Order-book snapshots and updates                                                                                            |
+| `candles`                 | Public         | Five-minute candle updates                                                                                                  |
+| `status`                  | Public         | Product and currency status                                                                                                 |
+| `user`                    | Required       | Current open orders and later order or position changes                                                                     |
+| `futures_balance_summary` | Required       | Futures balance changes for eligible accounts                                                                               |
+
+Coinbase requires one channel per Advanced Trade subscription request. Send separate `subscribe()` calls when a process needs ticker and heartbeat data.
+
+### Treat responses and updates differently
+
+The SDK emits:
+
+- `open` when a connection is ready.
+- `response` for subscription responses and exchange errors.
+- `update` for snapshots and later channel data.
+- `reconnect` when it begins restoring a dropped connection.
+- `reconnected` after the replacement connection opens.
+- `close` when a connection closes.
+- `exception` for connection, parsing, and Coinbase-reported authentication or subscription failures.
+
+`subscribe()` returns synchronously. The signed subscription request is sent asynchronously, so handle Coinbase rejections on `exception` rather than wrapping `subscribe()` in `try`/`catch`.
+
+Keep each event's `wsKey`, `channel`, `sequence_num`, and event `type`. A `subscriptions` response confirms the requested channel is active. It does not replace the initial channel snapshot or later updates.
+
+<!-- siebly:section id="reconnect-recovery" -->
+
+## Recover private state after a reconnect
+
+Automatic reconnection restores the socket and cached subscriptions. It cannot prove that every private event was received before or during the gap. Rebuild the affected [account state](https://siebly.io/reference/glossary#accountstate) through the REST API after `advTradeUserData` reconnects.
+
+This example reloads accounts, open orders, and recent `BTC-USD` fills sequentially. It replaces local state only when all three reads succeed.
+
+<!-- siebly:snippet id="reconnect-recovery" -->
+
+```javascript
+import {
+  CBAdvancedTradeClient,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from 'coinbase-api';
+
+async function main() {
+  if (
+    !process.env.COINBASE_API_KEY_NAME ||
+    !process.env.COINBASE_API_PRIVATE_KEY
+  ) {
+    console.error('Set COINBASE_API_KEY_NAME and COINBASE_API_PRIVATE_KEY.');
+    return;
+  }
+
+  const credentials = {
+    apiKey: process.env.COINBASE_API_KEY_NAME,
+    apiSecret: process.env.COINBASE_API_PRIVATE_KEY,
+  };
+
+  const rest = new CBAdvancedTradeClient(credentials);
+  const ws = new WebsocketClient(credentials);
+
+  let accountState;
+
+  ws.on('update', (update) => {
+    console.log('Private update:', update.channel, update.events);
+  });
+
+  ws.on('reconnected', async ({ wsKey }) => {
+    if (wsKey !== WS_KEY_MAP.advTradeUserData) {
+      return;
+    }
+
+    let accountsResponse;
+    let ordersResponse;
+    let fillsResponse;
+
+    try {
+      accountsResponse = await rest.getAccounts({
+        limit: 250,
+      });
+    } catch (error) {
+      console.error('Account recovery failed:', error);
+      return;
+    }
+
+    try {
+      ordersResponse = await rest.getOrders({
+        order_status: ['OPEN'],
+        limit: 250,
+      });
+    } catch (error) {
+      console.error('Open-order recovery failed:', error);
+      return;
+    }
+
+    try {
+      fillsResponse = await rest.getFills({
+        product_ids: ['BTC-USD'],
+        limit: 100,
+      });
+    } catch (error) {
+      console.error('Fill recovery failed:', error);
+      return;
+    }
+
+    const replacement = {
+      accounts: accountsResponse.accounts,
+      openOrders: ordersResponse.orders,
+      recentFills: fillsResponse.fills,
+      recoveredAt: new Date().toISOString(),
+    };
+
+    accountState = replacement;
+    console.log('Private state recovered:', accountState.recoveredAt);
+  });
+
+  ws.on('exception', (error) => {
+    console.error('WebSocket exception:', error);
+  });
+
+  ws.subscribe(
+    {
+      topic: 'user',
+      payload: {
+        product_ids: ['BTC-USD'],
+      },
+    },
+    WS_KEY_MAP.advTradeUserData,
+  );
+
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeUserData);
+
+  process.once('SIGINT', () => {
+    ws.closeAll();
+  });
+}
+
+main();
+```
+
+For a complete implementation, paginate until the required recovery window is covered. A production state owner should also buffer new private updates while recovery is running, apply the replacement snapshot, and then replay updates newer than the snapshot boundary.
+
+See:
+
+- [Exchange State](https://siebly.io/reference/exchange-state)
+- [REST API Hydration](https://siebly.io/reference/glossary#rest-hydration)
+- [Scoped Recovery](https://siebly.io/reference/glossary#scoped-recovery)
+- [Runtime Workflows](https://siebly.io/reference/runtime-workflows)
+
+## Choose the Coinbase API family
+
+The package covers several Coinbase products. Their credentials and account models are not interchangeable.
+
+| Client                  | Representative coverage                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| `CBAdvancedTradeClient` | Retail trading, portfolios, Spot, US futures, International perpetuals, fees, and converts        |
+| `CBAppClient`           | Coinbase App accounts, addresses, transactions, deposits, withdrawals, and public prices          |
+| `CBExchangeClient`      | Institutional Exchange products, accounts, orders, fills, profiles, reports, loans, and transfers |
+| `CBInternationalClient` | International instruments, portfolios, balances, positions, orders, fills, loans, and transfers   |
+| `CBPrimeClient`         | Prime portfolios, balances, orders, allocations, activities, wallets, and transactions            |
+| `CBCommerceClient`      | Legacy Commerce charges, checkouts, and events                                                    |
+
+Use Advanced Trade for a normal Coinbase retail trading account. Coinbase Exchange, International Exchange, and Prime require the matching institutional account and credentials.
+
+`CBCommerceClient` maps the legacy `api.commerce.coinbase.com` charge and checkout endpoints. Coinbase now directs new payment integrations toward Coinbase Business Checkouts. Review the official [Commerce-to-Checkouts migration guide](https://docs.cdp.coinbase.com/coinbase-business/checkout-apis/migrate-from-commerce/api-schema-mapping) before starting a new payments integration.
+
+<!-- siebly:section id="api-hosts" -->
+
+## Connect to live APIs and sandboxes
+
+Each Coinbase client has its own default REST API host. The WebSocket client selects a host from the requested `wsKey`.
+
+| API or environment             | REST API host                                             | WebSocket host or guidance                                                      |
+| ------------------------------ | --------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Advanced Trade live            | `https://api.coinbase.com`                                | `wss://advanced-trade-ws.coinbase.com` for market data                          |
+| Advanced Trade private stream  | `https://api.coinbase.com`                                | `wss://advanced-trade-ws-user.coinbase.com`                                     |
+| Advanced Trade static sandbox  | `https://api-sandbox.coinbase.com` via `useSandbox: true` | No Advanced Trade sandbox WebSocket                                             |
+| Coinbase App live              | `https://api.coinbase.com`                                | No Coinbase App stream in this SDK                                              |
+| Coinbase Exchange live         | `https://api.exchange.coinbase.com`                       | `wss://ws-feed.exchange.coinbase.com` or the authenticated direct feed          |
+| Coinbase Exchange sandbox      | `https://api-public.sandbox.exchange.coinbase.com`        | `wss://ws-feed-public.sandbox.exchange.coinbase.com` or its direct sandbox feed |
+| International Exchange live    | `https://api.international.coinbase.com`                  | `wss://ws-md.international.coinbase.com`                                        |
+| International Exchange sandbox | `https://api-n5e1.coinbase.com`                           | `wss://ws-md.n5e2.coinbase.com`                                                 |
+| Coinbase Prime live            | `https://api.prime.coinbase.com`                          | `wss://ws-feed.prime.coinbase.com`                                              |
+| Legacy Commerce live           | `https://api.commerce.coinbase.com`                       | No Commerce stream in this SDK                                                  |
+
+The [Advanced Trade static sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox) returns predefined mock responses for a limited set of account and order endpoints. It does not run a matching engine and is not a funded trading environment. Enable it on `CBAdvancedTradeClient` with `useSandbox: true` (REST only). There is no Advanced Trade WebSocket sandbox.
+
+`useSandbox: true` is also supported by `CBExchangeClient` and `CBInternationalClient`, and by the matching Exchange or International WebSocket connections. On `WebsocketClient`, `useSandbox` is client-wide: it applies to every `wsKey` on that instance. Do not set `useSandbox: true` on an Advanced Trade WebSocket connection. Sandbox credentials are separate from production credentials where the product requires them. Advanced Trade's static sandbox also accepts unauthenticated requests for its mocked endpoints.
+
+```javascript
+import { CBAdvancedTradeClient } from 'coinbase-api';
+
+const sandboxRest = new CBAdvancedTradeClient({
+  useSandbox: true,
+});
+```
+
+This tutorial's order examples still use live public market data plus `previewOrder()` for the safe Advanced Trade workflow.
+
+Official environment references:
+
+- [Advanced Trade sandbox](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/sandbox)
+- [Coinbase Exchange sandbox](https://docs.cdp.coinbase.com/exchange/introduction/sandbox)
+- [Coinbase International Exchange sandbox](https://docs.cdp.coinbase.com/international-exchange/introduction/sandbox)
+- [Coinbase Prime systems and operations](https://docs.cdp.coinbase.com/prime/introduction/systems-operations)
+
+Coinbase does not expose one generic region switch for every API family. Account type, portfolio access, jurisdiction, and product eligibility determine the available APIs and products. A proxy does not change those rules.
+
+<!-- siebly:section id="proxies" -->
+
+## Use a proxy with the REST API and WebSockets
+
+A proxy can provide a stable egress IP, an approved corporate network route, or controlled network failover. It changes the network path to Coinbase, not the selected API family, account permissions, jurisdiction, or product eligibility.
+
+See [Using a proxy with Siebly SDKs](https://siebly.io/blog/using-proxy-with-siebly-sdks) for the general networking pattern.
+
+### HTTP or HTTPS proxy
+
+Install the proxy agent:
+
+```bash
+npm install coinbase-api https-proxy-agent
+```
+
+Pass the agent through the second REST API client argument and through `wsOptions.agent` for WebSockets.
+
+<!-- siebly:snippet id="http-proxy" -->
+
+```javascript
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import {
+  CBAdvancedTradeClient,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from 'coinbase-api';
+
+async function main() {
+  if (!process.env.COINBASE_PROXY_URL) {
+    console.error('Set COINBASE_PROXY_URL.');
+    return;
+  }
+
+  const proxyAgent = new HttpsProxyAgent(process.env.COINBASE_PROXY_URL);
+
+  const rest = new CBAdvancedTradeClient(
+    {},
+    {
+      httpsAgent: proxyAgent,
+      proxy: false,
+    },
+  );
+
+  const ws = new WebsocketClient({
+    wsOptions: {
+      agent: proxyAgent,
+    },
+  });
+
+  try {
+    const serverTime = await rest.getServerTime();
+    console.log('REST API through proxy:', serverTime.iso);
+  } catch (error) {
+    console.error('Proxied REST API request failed:', error);
+  }
+
+  ws.on('open', ({ wsKey }) => {
+    console.log('Proxied WebSocket opened:', wsKey);
+  });
+
+  ws.on('response', (response) => {
+    console.log(
+      'Proxied WebSocket response:',
+      response.wsKey,
+      response.channel,
+    );
+  });
+
+  ws.on('update', (update) => {
+    console.log(
+      'Proxied WebSocket update:',
+      update.wsKey,
+      update.channel,
+      update.events,
+    );
+  });
+
+  ws.on('exception', (error) => {
+    console.error('Proxied WebSocket exception:', error);
+  });
+
+  ws.subscribe(
+    {
+      topic: 'ticker',
+      payload: {
+        product_ids: ['BTC-USD'],
+      },
+    },
+    WS_KEY_MAP.advTradeMarketData,
+  );
+
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
+
+  process.once('SIGINT', () => {
+    ws.closeAll();
+  });
+}
+
+main();
+```
+
+`httpsAgent` carries HTTPS REST API requests through the proxy. `proxy: false` prevents Axios from adding a second proxy layer. `HttpsProxyAgent` accepts both HTTP and HTTPS proxy URLs.
+
+For authenticated traffic, add credentials to the same constructors:
+
+```javascript
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { CBAdvancedTradeClient, WebsocketClient } from 'coinbase-api';
+
+function main() {
+  if (
+    !process.env.COINBASE_PROXY_URL ||
+    !process.env.COINBASE_API_KEY_NAME ||
+    !process.env.COINBASE_API_PRIVATE_KEY
+  ) {
+    console.error(
+      'Set COINBASE_PROXY_URL, COINBASE_API_KEY_NAME, and COINBASE_API_PRIVATE_KEY.',
+    );
+    return;
+  }
+
+  const proxyAgent = new HttpsProxyAgent(process.env.COINBASE_PROXY_URL);
+
+  const privateRest = new CBAdvancedTradeClient(
+    {
+      apiKey: process.env.COINBASE_API_KEY_NAME,
+      apiSecret: process.env.COINBASE_API_PRIVATE_KEY,
+    },
+    {
+      httpsAgent: proxyAgent,
+      proxy: false,
+    },
+  );
+
+  const privateWs = new WebsocketClient({
+    apiKey: process.env.COINBASE_API_KEY_NAME,
+    apiSecret: process.env.COINBASE_API_PRIVATE_KEY,
+    wsOptions: {
+      agent: proxyAgent,
+    },
+  });
+
+  console.log(
+    'Private REST API and WebSocket clients are configured:',
+    Boolean(privateRest),
+    Boolean(privateWs),
+  );
+}
+
+main();
+```
+
+This only constructs the authenticated clients. It does not make a private request, open a private stream, or submit an order.
+
+### SOCKS5 proxy
+
+Install:
+
+```bash
+npm install coinbase-api socks-proxy-agent
+```
+
+Use the same constructor positions with `SocksProxyAgent`.
+
+<!-- siebly:snippet id="socks-proxy" -->
+
+```javascript
+import { SocksProxyAgent } from 'socks-proxy-agent';
+import {
+  CBAdvancedTradeClient,
+  WebsocketClient,
+  WS_KEY_MAP,
+} from 'coinbase-api';
+
+async function main() {
+  if (!process.env.COINBASE_SOCKS_PROXY_URL) {
+    console.error('Set COINBASE_SOCKS_PROXY_URL.');
+    return;
+  }
+
+  const proxyAgent = new SocksProxyAgent(process.env.COINBASE_SOCKS_PROXY_URL);
+
+  const rest = new CBAdvancedTradeClient(
+    {},
+    {
+      httpsAgent: proxyAgent,
+      proxy: false,
+    },
+  );
+
+  const ws = new WebsocketClient({
+    wsOptions: {
+      agent: proxyAgent,
+    },
+  });
+
+  try {
+    const serverTime = await rest.getServerTime();
+    console.log('REST API through SOCKS5:', serverTime.iso);
+  } catch (error) {
+    console.error('SOCKS5 REST API request failed:', error);
+  }
+
+  ws.on('open', ({ wsKey }) => {
+    console.log('SOCKS5 WebSocket opened:', wsKey);
+  });
+
+  ws.on('response', (response) => {
+    console.log('SOCKS5 WebSocket response:', response.wsKey, response.channel);
+  });
+
+  ws.on('update', (update) => {
+    console.log(
+      'SOCKS5 WebSocket update:',
+      update.wsKey,
+      update.channel,
+      update.events,
+    );
+  });
+
+  ws.on('exception', (error) => {
+    console.error('SOCKS5 WebSocket exception:', error);
+  });
+
+  ws.subscribe(
+    {
+      topic: 'ticker',
+      payload: {
+        product_ids: ['BTC-USD'],
+      },
+    },
+    WS_KEY_MAP.advTradeMarketData,
+  );
+
+  ws.subscribe('heartbeats', WS_KEY_MAP.advTradeMarketData);
+
+  process.once('SIGINT', () => {
+    ws.closeAll();
+  });
+}
+
+main();
+```
+
+### Proxy checks
+
+- Keep proxy URLs and credentials in environment variables or a secret manager.
+- URL-encode proxy usernames and passwords when composing a URL from separate values.
+- Make sure the proxy egress IP matches the API key's IP allowlist.
+- Test a public REST API request and public WebSocket subscription before private authentication.
+- Monitor REST API latency, WebSocket connection time, and reconnect frequency.
+- Treat HTTP 407 responses, TLS failures, and repeated reconnects as network faults.
+- Do not log complete proxy URLs because they may contain credentials.
+- Keep the host clock synchronized because private request JWTs are time-sensitive.
+- The SDK does not rotate proxy endpoints.
+
+<!-- siebly:section id="production" -->
+
+## Production checklist
+
+### Keep request time accurate
+
+Advanced Trade JWTs are short-lived. Keep the host clock synchronized and alert on clock drift before it causes authentication failures.
+
+### Respect rate limits and caching
+
+Coinbase applies REST API, WebSocket connection, and message limits. Public Advanced Trade REST API endpoints can also use a short cache. Use WebSockets for continuously changing prices and books, follow current response headers, and back off after rate-limit responses.
+
+### Apply current product rules
+
+Read product metadata before validating an order. Apply the current increments, minimum and maximum sizes, trading status, venue, product type, session details, and account eligibility.
+
+Do not assume that the rules for `BTC-USD` apply to another Spot, futures, or perpetual product.
+
+### Use client order IDs
+
+Generate and persist a unique `client_order_id` for each application-owned order. Store it with the Coinbase order ID, product, side, configuration, requested size, and creation time.
+
+### Confirm final state
+
+An accepted write is not proof of a fill, cancellation, or final order status. Confirm through the private `user` stream or a REST API query.
+
+After an uncertain timeout, reconcile known identifiers before retrying.
+
+### Keep WebSocket streams healthy
+
+Subscribe to `heartbeats` alongside other Advanced Trade channels. Monitor sequence numbers, heartbeat counters, exceptions, reconnects, and time since the last update.
+
+Reload the affected account state after a private stream gap.
+
+### Scope credentials and network access
+
+Keep API keys and proxy credentials out of source control, browser bundles, logs, and error reporting. Grant only the required permissions and portfolio access. Use stable allowlisted egress IPs where practical.
+
+API keys in this guide are for a server acting on its own Coinbase account. An application acting for other Coinbase users should use Coinbase's current OAuth flow rather than collecting users' private API keys.
+
+### Shut down connections
+
+Call `closeAll()` during controlled process shutdown. Use `unsubscribe()` only when a long-running process should stop selected topics while keeping a connection active.
+
+## FAQ
+
+### Does `coinbase-api` work with plain JavaScript?
+
+Yes. Every example in this tutorial is plain JavaScript. The package also publishes TypeScript declarations for projects that use them.
+
+### Which REST API client should I use?
+
+Use `CBAdvancedTradeClient` for a normal Coinbase retail trading account. Use the App, Exchange, International, Prime, or Commerce client only when the Coinbase account and workflow belong to that API family.
+
+### What are `COINBASE_API_KEY_NAME` and `COINBASE_API_PRIVATE_KEY`?
+
+The key name identifies a Coinbase Developer Platform secret API key. The private key signs requests and subscriptions. It is not the Coinbase account password.
+
+### Does Advanced Trade use an API passphrase?
+
+No. Advanced Trade and Coinbase App use a key name and private signing key. Exchange, International Exchange, and Prime credentials include a separate API passphrase.
+
+### Can I use ECDSA and Ed25519 keys?
+
+`coinbase-api` supports both current Coinbase key formats and detects the signing algorithm from the private key. Preserve the complete ECDSA PEM or base64 Ed25519 value.
+
+### Why do Advanced Trade REST API responses have different shapes?
+
+The SDK returns each endpoint body directly. A product is one object, accounts are under `accounts`, orders are under `orders`, candles are under `candles`, and trades are under `trades`.
+
+### Why can an order response fail with an HTTP success status?
+
+Some order-management endpoints report operation-level success inside the response body. Check `success`, then read `success_response` or `error_response` as appropriate.
+
+### What is the difference between Advanced Trade and Coinbase Exchange?
+
+Advanced Trade is the normal Coinbase trading API for retail users. Coinbase Exchange is an institutional API product with separate accounts, credentials, permissions, hosts, and market structure.
+
+### Does Advanced Trade have a sandbox?
+
+Yes, a static REST sandbox. `useSandbox: true` on `CBAdvancedTradeClient` routes to `https://api-sandbox.coinbase.com`. Responses are predefined mocks for selected account and order endpoints. It does not run a matching engine, and there is no Advanced Trade WebSocket sandbox.
+
+### Does `previewOrder()` place an order?
+
+No. It validates and estimates the request but does not submit it to the matching engine. Check `errs` and `warning` before using its estimates.
+
+### Why is there no Coinbase `WebsocketAPIClient`?
+
+The Coinbase WebSocket interfaces supported by this SDK are subscription feeds. Use `WebsocketClient` for streams and the matching REST API client for order commands.
+
+### What does the first private `user` update contain?
+
+Coinbase sends current open-order snapshots before later changes. Large snapshots can be split across multiple messages, so process event types and sequence information rather than treating the first message as complete.
+
+### Why should I subscribe to `heartbeats`?
+
+Heartbeats keep quiet Advanced Trade subscriptions open and expose a counter that can help detect missed messages.
+
+### What should happen after a private WebSocket reconnect?
+
+Restore the subscription, then reload affected account state through the REST API. Replace local state only after the required reads complete and reconcile updates received during recovery.
+
+### What causes timestamp or signature errors?
+
+Common causes include clock drift, an incorrectly stored private key, lost PEM line breaks, a key for the wrong API family, insufficient portfolio permissions, or a proxy sending traffic from an unexpected IP.
+
+### Can a proxy change Coinbase product availability?
+
+No. A proxy changes the network route. It does not change the API family, account region, jurisdiction, portfolio permissions, or product eligibility.
+
+### Can I use API keys for other Coinbase users?
+
+API key authentication is for server-side access to an account you control. Use Coinbase's current OAuth guidance when an application needs authorization from other users.
+
+## Next steps
+
+- [Coinbase JavaScript SDK page](https://siebly.io/sdk/coinbase/javascript)
+- [`coinbase-api` on npm](https://www.npmjs.com/package/coinbase-api)
+- [Coinbase SDK source](https://github.com/tiagosiebler/coinbase-api)
+- [Coinbase examples on Siebly](https://siebly.io/examples/Coinbase)
+- [SDK endpoint map](./endpointFunctionList.md)
+- [Advanced Trade REST API documentation](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/rest-api)
+- [Advanced Trade WebSocket documentation](https://docs.cdp.coinbase.com/coinbase-app/advanced-trade-apis/websocket/websocket-overview)
+- [Coinbase authentication documentation](https://docs.cdp.coinbase.com/coinbase-app/authentication-authorization/api-key-authentication)
+- [Siebly glossary](https://siebly.io/reference/glossary)
+- [Exchange State](https://siebly.io/reference/exchange-state)
+- [Runtime Workflows](https://siebly.io/reference/runtime-workflows)
 
 ================
 File: README.md
@@ -9667,8 +11271,8 @@ File: README.md
 <p align="center">
   <a href="https://www.npmjs.com/package/coinbase-api">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/tiagosiebler/coinbase-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
-      <img alt="SDK Logo" src="https://github.com/tiagosiebler/coinbase-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
+      <source media="(prefers-color-scheme: dark)" srcset="https://github.com/sieblyio/coinbase-api/blob/master/docs/images/logoDarkMode2.svg?raw=true#gh-dark-mode-only">
+      <img alt="SDK Logo" src="https://github.com/sieblyio/coinbase-api/blob/master/docs/images/logoBrightMode2.svg?raw=true#gh-light-mode-only">
     </picture>
   </a>
 </p>
@@ -9676,15 +11280,15 @@ File: README.md
 [![npm version](https://img.shields.io/npm/v/coinbase-api)][1]
 [![npm size](https://img.shields.io/bundlephobia/min/coinbase-api/latest)][1]
 [![npm downloads](https://img.shields.io/npm/dt/coinbase-api)][1]
-[![Build & Test](https://github.com/tiagosiebler/coinbase-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/tiagosiebler/coinbase-api/actions/workflows/e2etest.yml)
-[![last commit](https://img.shields.io/github/last-commit/tiagosiebler/coinbase-api)][1]
+[![Build & Test](https://github.com/sieblyio/coinbase-api/actions/workflows/e2etest.yml/badge.svg?branch=master)](https://github.com/sieblyio/coinbase-api/actions/workflows/e2etest.yml)
+[![last commit](https://img.shields.io/github/last-commit/sieblyio/coinbase-api)][1]
 [![Telegram](https://img.shields.io/badge/chat-on%20telegram-blue.svg)](https://t.me/nodetraders)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/tiagosiebler/coinbase-api)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/sieblyio/coinbase-api)
 
 [1]: https://www.npmjs.com/package/coinbase-api
 
 > [!TIP]
-> Upcoming change: As part of the [Siebly.io](https://siebly.io/?ref=ghcoinbase) brand, this SDK will soon be hosted under the [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
+> Upcoming change: As part of the [Siebly.io](https://siebly.io/?ref=ghcoinbase) brand, this SDK is now hosted under our [Siebly.io GitHub organisation](https://github.com/sieblyio). The migration is seamless and requires no user changes.
 
 Updated & performant JavaScript & Node.js SDK for Coinbase's Advanced Trade, App, Exchange, International, Prime & Commerce REST APIs and WebSockets:
 
@@ -9749,7 +11353,7 @@ Refer to the [examples](./examples) folder for implementation examples.
 
 ## Issues & Discussion
 
-- Issues? Check the [issues tab](https://github.com/tiagosiebler/coinbase-api/issues).
+- Issues? Check the [issues tab](https://github.com/sieblyio/coinbase-api/issues).
 - Discuss & collaborate with other node devs? Join our [Node.js Algo Traders](https://t.me/nodetraders) engineering community on telegram.
 - Follow our announcement channel for real-time updates on [X/Twitter](https://x.com/sieblyio)
 
@@ -9759,22 +11363,22 @@ Refer to the [examples](./examples) folder for implementation examples.
 
 Check out our JavaScript/TypeScript/Node.js SDKs & Projects:
 
-- Visit our website: [https://Siebly.io](https://siebly.io/?ref=gh)
+- Visit our website: [https://Siebly.io](https://siebly.io/)
 - Try our REST API & WebSocket SDKs published on npmjs:
-  - [Bybit Node.js SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
-  - [Kraken Node.js SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
-  - [OKX Node.js SDK: okx-api](https://www.npmjs.com/package/okx-api)
-  - [Binance Node.js SDK: binance](https://www.npmjs.com/package/binance)
-  - [Gate (gate.com) Node.js SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
-  - [Bitget Node.js SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
-  - [Kucoin Node.js SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
-  - [Coinbase Node.js SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
-  - [Bitmart Node.js SDK: bitmart-api](https://www.npmjs.com/package/bitmart-api)
+  - [Bybit JavaScript SDK: bybit-api](https://www.npmjs.com/package/bybit-api)
+  - [Kraken JavaScript SDK: @siebly/kraken-api](https://www.npmjs.com/package/@siebly/kraken-api)
+  - [OKX JavaScript SDK: okx-api](https://www.npmjs.com/package/okx-api)
+  - [Binance JavaScript SDK: binance](https://www.npmjs.com/package/binance)
+  - [Gate (gate.com) JavaScript SDK: gateio-api](https://www.npmjs.com/package/gateio-api)
+  - [Bitget JavaScript SDK: bitget-api](https://www.npmjs.com/package/bitget-api)
+  - [Kucoin JavaScript SDK: kucoin-api](https://www.npmjs.com/package/kucoin-api)
+  - [Coinbase JavaScript SDK: coinbase-api](https://www.npmjs.com/package/coinbase-api)
+  - [HTX JavaScript SDK: @siebly/htx-api](https://www.npmjs.com/package/@siebly/htx-api)
 - Try my misc utilities:
   - [OrderBooks Node.js: orderbooks](https://www.npmjs.com/package/orderbooks)
   - [Crypto Exchange Account State Cache: accountstate](https://www.npmjs.com/package/accountstate)
 - Check out my examples:
-  - [awesome-crypto-examples Node.js](https://github.com/tiagosiebler/awesome-crypto-examples)
+  - [awesome-crypto-examples Node.js](https://github.com/sieblyio/awesome-crypto-examples)
   <!-- template_related_projects_end -->
 
 ## Documentation
@@ -10236,7 +11840,7 @@ This file contains AI optimised structure of all the functions in this package, 
 
 ## Used By
 
-[![Repository Users Preview Image](https://dependents.info/tiagosiebler/coinbase-api/image)](https://github.com/tiagosiebler/coinbase-api/network/dependents)
+[![Repository Users Preview Image](https://dependents.info/sieblyio/coinbase-api/image)](https://github.com/sieblyio/coinbase-api/network/dependents)
 
 ---
 
@@ -10254,7 +11858,7 @@ Have my projects helped you? Share the love, there are many ways you can show yo
 - Sign up with my referral links:
   - OKX (receive a 20% fee discount!): https://www.okx.com/join/42013004
   - Binance (receive a 20% fee discount!): https://accounts.binance.com/register?ref=OKFFGIJJ
-  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SDK
+  - HyperLiquid (receive a 4% fee discount!): https://app.hyperliquid.xyz/join/SIEBLY
   - Gate: https://www.gate.io/signup/NODESDKS?ref_type=103
 
 <!---
@@ -10276,7 +11880,7 @@ Contributions are encouraged, I will review any incoming pull requests. See the 
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=tiagosiebler/bybit-api,tiagosiebler/okx-api,tiagosiebler/binance,tiagosiebler/bitget-api,tiagosiebler/bitmart-api,tiagosiebler/gateio-api,tiagosiebler/kucoin-api,tiagosiebler/coinbase-api,tiagosiebler/orderbooks,tiagosiebler/accountstate,tiagosiebler/awesome-crypto-examples&type=Date)](https://star-history.com/#tiagosiebler/bybit-api&tiagosiebler/okx-api&tiagosiebler/binance&tiagosiebler/bitget-api&tiagosiebler/bitmart-api&tiagosiebler/gateio-api&tiagosiebler/kucoin-api&tiagosiebler/coinbase-api&tiagosiebler/orderbooks&tiagosiebler/accountstate&tiagosiebler/awesome-crypto-examples&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=sieblyio/bybit-api,sieblyio/okx-api,sieblyio/binance,sieblyio/bitget-api,sieblyio/bitmart-api,sieblyio/gateio-api,sieblyio/kucoin-api,sieblyio/coinbase-api,sieblyio/orderbooks,sieblyio/accountstate,sieblyio/awesome-crypto-examples&type=Date)](https://star-history.com/#sieblyio/bybit-api&sieblyio/okx-api&sieblyio/binance&sieblyio/bitget-api&sieblyio/bitmart-api&sieblyio/gateio-api&sieblyio/kucoin-api&sieblyio/coinbase-api&sieblyio/orderbooks&sieblyio/accountstate&sieblyio/awesome-crypto-examples&Date)
 
 <!-- template_star_history_end -->
 
@@ -10285,7 +11889,7 @@ File: package.json
 ================
 {
   "name": "coinbase-api",
-  "version": "1.1.13",
+  "version": "1.2.4",
   "description": "Node.js SDK for Coinbase's Advanced Trade, App, Exchange, International, Prime & Commerce REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",
@@ -10318,16 +11922,16 @@ File: package.json
     "Jerko J (https://github.com/JJ-Cro)"
   ],
   "dependencies": {
+    "@types/ws": "^8.18.1",
     "axios": "^1.13.2",
     "isomorphic-ws": "^4.0.1",
     "jose": "^6.1.3",
     "nanoid": "^3.3.11",
-    "ws": "^7.4.0"
+    "ws": "8.21.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",
     "@types/node": "^22.10.2",
-    "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^8.18.0",
     "@typescript-eslint/parser": "^8.18.0",
     "eslint": "^8.29.0",
@@ -10341,7 +11945,6 @@ File: package.json
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",
     "webpack": "^5.0.0",
-    "webpack-bundle-analyzer": "^5.1.1",
     "webpack-cli": "^4.0.0"
   },
   "keywords": [
@@ -10369,12 +11972,12 @@ File: package.json
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tiagosiebler/coinbase-api.git"
+    "url": "git+https://github.com/sieblyio/coinbase-api.git"
   },
   "bugs": {
-    "url": "https://github.com/tiagosiebler/coinbase-api/issues"
+    "url": "https://github.com/sieblyio/coinbase-api/issues"
   },
-  "homepage": "https://github.com/tiagosiebler/coinbase-api#readme"
+  "homepage": "https://github.com/sieblyio/coinbase-api#readme"
 }
 
 

--- a/llms.txt
+++ b/llms.txt
@@ -7671,6 +7671,11 @@ getWrappedAssetConversionRate(params: {
 }): Promise<any>
 
 ================
+File: .nvmrc
+================
+v24.18.0
+
+================
 File: LICENSE.md
 ================
 Copyright 2025 Tiago Siebler
@@ -8897,11 +8902,6 @@ function generateConfig(name)
 // The REST client's https.Agent (for keepAlive) is Node.js-only and won't work in browsers
 ⋮----
 // Code is already transpiled from TypeScript, no additional loaders needed
-
-================
-File: .nvmrc
-================
-v24.18.0
 
 ================
 File: src/lib/BaseRestClient.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "coinbase-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "coinbase-api",
-      "version": "1.2.3",
+      "version": "1.2.4",
       "license": "MIT",
       "dependencies": {
         "@types/ws": "^8.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coinbase-api",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Node.js SDK for Coinbase's Advanced Trade, App, Exchange, International, Prime & Commerce REST APIs and WebSockets, with TypeScript & strong end to end tests.",
   "scripts": {
     "clean": "rm -rf dist",

--- a/src/CBAppClient.ts
+++ b/src/CBAppClient.ts
@@ -16,6 +16,7 @@ import {
 import {
   CBAppAccount,
   CBAppAddress,
+  CBAppCoinbaseOneSubscription,
   CBAppCryptocurrency,
   CBAppDepositWithdrawal,
   CBAppFiatCurrency,
@@ -406,6 +407,24 @@ export class CBAppClient extends BaseRestClient {
     return this.getPrivate(
       `/v2/accounts/${params.account_id}/withdrawals/${params.withdrawal_id}`,
     );
+  }
+
+  /**
+   *
+   * Subscriptions Endpoints
+   *
+   */
+
+  /**
+   * Get Coinbase One Subscription
+   *
+   * Returns a user's Coinbase One subscription status, tier, and current period end.
+   * Requires OAuth2 scope: wallet:subscription:read
+   */
+  getCoinbaseOneSubscription(): Promise<{
+    data: CBAppCoinbaseOneSubscription;
+  }> {
+    return this.getPrivate('/v2/subscriptions/coinbase-one');
   }
 
   /**

--- a/src/CBPrimeClient.ts
+++ b/src/CBPrimeClient.ts
@@ -38,6 +38,7 @@ import {
   GetPrimePortfolioUsersRequest,
   GetPrimePortfolioWalletsRequest,
   GetPrimePortfolioWithdrawalPowerRequest,
+  GetPrimeTransactionTravelRuleDataRequest,
   GetPrimeUsersRequest,
   GetPrimeWalletDepositInstructionsRequest,
   GetPrimeWalletTransactionsRequest,
@@ -749,6 +750,26 @@ export class CBPrimeClient extends BaseRestClient {
     const { portfolio_id, transaction_id } = params;
     return this.getPrivate(
       `/v1/portfolios/${portfolio_id}/transactions/${transaction_id}`,
+    );
+  }
+
+  /**
+   *
+   * Travel Rule Endpoints
+   *
+   */
+
+  /**
+   * Get Transaction Travel Rule Data
+   *
+   * (Beta) Get fulfilled travel rule data for a transaction.
+   */
+  getTransactionTravelRuleData(
+    params: GetPrimeTransactionTravelRuleDataRequest,
+  ): Promise<any> {
+    const { portfolio_id, transaction_id } = params;
+    return this.getPrivate(
+      `/v1/portfolios/${portfolio_id}/transactions/${transaction_id}/travel_rule`,
     );
   }
 

--- a/src/types/request/coinbase-prime.ts
+++ b/src/types/request/coinbase-prime.ts
@@ -325,8 +325,31 @@ export interface GetPrimeOrderFillsRequest {
 export interface GetPrimePortfolioProductsRequest {
   portfolio_id: string;
   cursor?: string;
+  /** Must be between 0 and 1000 (defaults to 10 when unset). Values > 1000 are rejected. */
   limit?: number;
   sort_direction?: 'DESC' | 'ASC';
+  /** If unset, returns all product types available for the portfolio (including FUTURE). */
+  product_type?: 'SPOT' | 'FUTURE' | 'OPTION';
+  /** Only applicable when product_type = FUTURE. */
+  contract_expiry_type?:
+    | 'CONTRACT_EXPIRY_TYPE_EXPIRING'
+    | 'CONTRACT_EXPIRY_TYPE_PERPETUAL';
+  /** Filter by expiry status for expiring futures. */
+  expiring_contract_status?:
+    | 'EXPIRING_CONTRACT_STATUS_UNEXPIRED'
+    | 'EXPIRING_CONTRACT_STATUS_EXPIRED'
+    | 'EXPIRING_CONTRACT_STATUS_ALL';
+}
+
+/**
+ *
+ * Travel Rule Endpoints
+ *
+ */
+
+export interface GetPrimeTransactionTravelRuleDataRequest {
+  portfolio_id: string;
+  transaction_id: string;
 }
 
 /**

--- a/src/types/response/coinbase-app-client.ts
+++ b/src/types/response/coinbase-app-client.ts
@@ -247,6 +247,18 @@ export interface CBAppTransfer {
 }
 /**
  *
+ * Subscriptions Endpoints
+ *
+ */
+
+export interface CBAppCoinbaseOneSubscription {
+  status: string;
+  tier: string;
+  current_period_end: string;
+}
+
+/**
+ *
  * DATA - Currencies Endpoints
  *
  */


### PR DESCRIPTION
- Introduced `getCoinbaseOneSubscription` method in `CBAppClient` to retrieve user's Coinbase One subscription status.
- Added `getTransactionTravelRuleData` method in `CBPrimeClient` for fetching travel rule data for transactions.
- Updated request and response types to support new endpoints.
- Enhanced examples for both endpoints in the documentation.
- Bumped version to 1.2.4 in package files.